### PR TITLE
fix issue when using the webhook parameter

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -31,7 +31,7 @@ commands:
           name: Slack Notification
           command: |
             # Provide error if no webhook is set and error. Otherwise continue
-            if [ -z "$SLACK_WEBHOOK" ]; then
+            if [ -z "<< parameters.webhook >>" ]; then
               echo "NO SLACK WEBHOOK SET"
               echo "Please input your SLACK_WEBHOOK value either in the settings for this project, or as a parameter for this orb."
               exit 1
@@ -79,7 +79,7 @@ commands:
           name: Slack - Sending Status Alert
           command: |
             # Provide error if no webhook is set and error. Otherwise continue
-            if [ -z "$SLACK_WEBHOOK" ]; then
+            if [ -z "<< parameters.webhook >>" ]; then
               echo "NO SLACK WEBHOOK SET"
               echo "Please input your SLACK_WEBHOOK value either in the settings for this project, or as a parameter for this orb."
               exit 1


### PR DESCRIPTION
Hello there @iynere and @eddiewebb,

I'm having the same issue described here: [issues/2](https://github.com/CircleCI-Public/slack-orb/issues/2). The problem happens because the env **$SLACK_WEBHOOK** is always checked, even when the parameter **webhook** is set.

What do you think about this solution? Is there a better way to fix it?

Thanks!