### PR TITLE
Added option to trigger notifications on a specific branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See Slack's [Basic message formatting](https://api.slack.com/docs/message-format
 |  Usage | slack/status   |
 | ------------ | ------------ |
 | **Description:** | Send a status alert at the end of a job based on success or failure. This must be the last step in a job. |
-|  **Parameters:** | -  **webhook:** Enter either your Webhook value or use the CircleCI UI to add your token under the `SLACK_WEBHOOK` environment variable <br> <br> - **fail_only:** `false` by default. If set to `true, successful jobs will _not_ send alerts <br> <br> - **mentions:**  comma separated list of Slack user IDs, or Group (SubTeam) IDs. example 'USER1,USER2,USER3'. Note, these are Slack User IDs, not usernames. The user ID can be found on the user's profile. Look below for infomration on obtaining Group ID. |
+|  **Parameters:** | -  **webhook:** Enter either your Webhook value or use the CircleCI UI to add your token under the `SLACK_WEBHOOK` environment variable <br> <br> - **fail_only:** `false` by default. If set to `true, successful jobs will _not_ send alerts <br> <br> - **mentions:**  comma separated list of Slack user IDs, or Group (SubTeam) IDs. example 'USER1,USER2,USER3'. Note, these are Slack User IDs, not usernames. The user ID can be found on the user's profile. Look below for infomration on obtaining Group ID. <br> <br> - **only_for_branch**: Optional: If set, a specific branch for which status updates will be sent. |
 
 Example:
 
@@ -84,6 +84,7 @@ jobs:
           mentions: "USERID1,USERID2" # Optional: Enter the Slack IDs of any user or group (sub_team) to be mentioned
           fail_only: "true" # Optional: if set to "true" then only failure messages will occur.
           webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
+          only_for_branch: "master" # Optional: If set, a specific branch for which status updates will be sent. In this case, only for pushes to master branch.
 ```
 
 ![Status Success Example](/img/statusSuccess.PNG)

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -86,6 +86,10 @@ commands:
         description: A comma separated list of user IDs. No spaces.
         type: string
         default: ""
+      only_for_branch:
+        description: If, set, a specific branch for which slack status updates will be sent.
+        type: string
+        default: ""
     steps:
       - run:
           name: Slack - Setting Failure Condition
@@ -110,37 +114,39 @@ commands:
           name: Slack - Sending Status Alert
           shell: /bin/bash
           command: |
-            # Provide error if no webhook is set and error. Otherwise continue
-            if [ -z "<< parameters.webhook >>" ]; then
-              echo "NO SLACK WEBHOOK SET"
-              echo "Please input your SLACK_WEBHOOK value either in the settings for this project, or as a parameter for this orb."
-              exit 1
-            else
-              #Create Members string
-              if [ -n "<< parameters.mentions >>" ]; then
-                IFS="," read -ra SLACK_MEMBERS \<<< "<< parameters.mentions >>"
-                for i in "${SLACK_MEMBERS[@]}"; do
-                  if [ $(echo ${i} | head -c 1) == "S" ]; then
-                    SLACK_MENTIONS="${SLACK_MENTIONS}<!subteam^${i}> "
-                  else
-                    SLACK_MENTIONS="${SLACK_MENTIONS}<@${i}> "
-                  fi
-                done
-              fi
-              #If successful
-              if [ "$SLACK_BUILD_STATUS" = "success" ]; then
-                #Skip if fail_only
-                if [ << parameters.fail_only >> = true ]; then
-                  echo "The job completed successfully"
-                  echo '"fail_only" is set to "true". No Slack notification sent.'
-                else
-                  curl -X POST -H 'Content-type: application/json' --data "{ \"attachments\": [ { \"fallback\": \"A job has succeeded - $CIRCLE_BUILD_URL\", \"text\": \":tada: A $CIRCLE_JOB job has succeeded! $SLACK_MENTIONS\", \"fields\": [ { \"title\": \"Project\", \"value\": \"$CIRCLE_PROJECT_REPONAME\", \"short\": true }, { \"title\": \"Job Number\", \"value\": \"$CIRCLE_BUILD_NUM\", \"short\": true } ], \"actions\": [ { \"type\": \"button\", \"text\": \"Visit Job\", \"url\": \"$CIRCLE_BUILD_URL\" } ], \"color\": \"#1CBF43\" } ] } " << parameters.webhook >>
-                  echo "Job completed successfully. Alert sent."
-                fi
+            if [ "x" == "x<< parameters.only_for_branch>>" ] || [ "${CIRCLE_BRANCH}" == "<< parameters.only_for_branch>>" ]; then
+              # Provide error if no webhook is set and error. Otherwise continue
+              if [ -z "<< parameters.webhook >>" ]; then
+                echo "NO SLACK WEBHOOK SET"
+                echo "Please input your SLACK_WEBHOOK value either in the settings for this project, or as a parameter for this orb."
+                exit 1
               else
-                #If Failed
-                curl -X POST -H 'Content-type: application/json' --data "{ \"attachments\": [ { \"fallback\": \"A job has failed - $CIRCLE_BUILD_URL\", \"text\": \":red_circle: A $CIRCLE_JOB job has failed! $SLACK_MENTIONS\", \"fields\": [ { \"title\": \"Project\", \"value\": \"$CIRCLE_PROJECT_REPONAME\", \"short\": true }, { \"title\": \"Job Number\", \"value\": \"$CIRCLE_BUILD_NUM\", \"short\": true } ], \"actions\": [ { \"type\": \"button\", \"text\": \"Visit Job\", \"url\": \"$CIRCLE_BUILD_URL\" } ], \"color\": \"#ed5c5c\" } ] } " << parameters.webhook >>
-                echo "Job failed. Alert sent."
+                #Create Members string
+                if [ -n "<< parameters.mentions >>" ]; then
+                  IFS="," read -ra SLACK_MEMBERS \<<< "<< parameters.mentions >>"
+                  for i in "${SLACK_MEMBERS[@]}"; do
+                    if [ $(echo ${i} | head -c 1) == "S" ]; then
+                      SLACK_MENTIONS="${SLACK_MENTIONS}<!subteam^${i}> "
+                    else
+                      SLACK_MENTIONS="${SLACK_MENTIONS}<@${i}> "
+                    fi
+                  done
+                fi
+                #If successful
+                if [ "$SLACK_BUILD_STATUS" = "success" ]; then
+                  #Skip if fail_only
+                  if [ << parameters.fail_only >> = true ]; then
+                    echo "The job completed successfully"
+                    echo '"fail_only" is set to "true". No Slack notification sent.'
+                  else
+                    curl -X POST -H 'Content-type: application/json' --data "{ \"attachments\": [ { \"fallback\": \"A job has succeeded - $CIRCLE_BUILD_URL\", \"text\": \":tada: A $CIRCLE_JOB job has succeeded! $SLACK_MENTIONS\", \"fields\": [ { \"title\": \"Project\", \"value\": \"$CIRCLE_PROJECT_REPONAME\", \"short\": true }, { \"title\": \"Job Number\", \"value\": \"$CIRCLE_BUILD_NUM\", \"short\": true } ], \"actions\": [ { \"type\": \"button\", \"text\": \"Visit Job\", \"url\": \"$CIRCLE_BUILD_URL\" } ], \"color\": \"#1CBF43\" } ] } " << parameters.webhook >>
+                    echo "Job completed successfully. Alert sent."
+                  fi
+                else
+                  #If Failed
+                  curl -X POST -H 'Content-type: application/json' --data "{ \"attachments\": [ { \"fallback\": \"A job has failed - $CIRCLE_BUILD_URL\", \"text\": \":red_circle: A $CIRCLE_JOB job has failed! $SLACK_MENTIONS\", \"fields\": [ { \"title\": \"Project\", \"value\": \"$CIRCLE_PROJECT_REPONAME\", \"short\": true }, { \"title\": \"Job Number\", \"value\": \"$CIRCLE_BUILD_NUM\", \"short\": true } ], \"actions\": [ { \"type\": \"button\", \"text\": \"Visit Job\", \"url\": \"$CIRCLE_BUILD_URL\" } ], \"color\": \"#ed5c5c\" } ] } " << parameters.webhook >>
+                  echo "Job failed. Alert sent."
+                fi
               fi
             fi
           when: always
@@ -181,3 +187,4 @@ examples:
                 mentions: "USERID1,USERID2" # Optional: Enter the Slack IDs of any user or group (sub_team) to be mentioned
                 fail_only: "true" # Optional: if set to "true" then only failure messages will occur.
                 webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
+                only_for_branch: "only_for_branch" # Optional: If set, a specific branch for which status updates will be sent.


### PR DESCRIPTION
Added a new parameter - `only_for_branch` - to the `slack/notify` command, which allows slack updates to be triggered for builds on a specific branch only.

Fixes https://github.com/CircleCI-Public/slack-orb/issues/17