### PR TITLE
improve formatting for `curl` commands

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -67,7 +67,36 @@ commands:
                   fi
                 done
               fi
-              curl -X POST -H 'Content-type: application/json' --data "{ \"attachments\": [ { \"fallback\": \"<< parameters.message >> - $CIRCLE_BUILD_URL\", \"text\": \"<< parameters.message >> $SLACK_MENTIONS\", \"fields\": [ { \"title\": \"Project\", \"value\": \"$CIRCLE_PROJECT_REPONAME\", \"short\": true }, { \"title\": \"Job Number\", \"value\": \"$CIRCLE_BUILD_NUM\", \"short\": true } ], \"actions\": [ { \"type\": \"button\", \"text\": \"Visit Job\", \"url\": \"$CIRCLE_BUILD_URL\" } ], \"color\": \"<< parameters.color >>\" } ] }" << parameters.webhook >>
+              curl -X POST -H 'Content-type: application/json' \
+                --data \
+                "{ \
+                  \"attachments\": [ \
+                    { \
+                      \"fallback\": \"<< parameters.message >> - $CIRCLE_BUILD_URL\", \
+                      \"text\": \"<< parameters.message >> $SLACK_MENTIONS\", \
+                      \"fields\": [ \
+                        { \
+                          \"title\": \"Project\", \
+                          \"value\": \"$CIRCLE_PROJECT_REPONAME\", \
+                          \"short\": true \
+                        }, \
+                        { \
+                          \"title\": \"Job Number\", \
+                          \"value\": \"$CIRCLE_BUILD_NUM\", \
+                          \"short\": true \
+                        } \
+                      ], \
+                      \"actions\": [ \
+                        { \
+                          \"type\": \"button\", \
+                          \"text\": \"Visit Job\", \
+                          \"url\": \"$CIRCLE_BUILD_URL\" \
+                        } \
+                      ], \
+                      \"color\": \"<< parameters.color >>\" \
+                    } \
+                  ] \
+                }" << parameters.webhook >>
             fi
 
   ## STATUS ##
@@ -139,12 +168,66 @@ commands:
                     echo "The job completed successfully"
                     echo '"fail_only" is set to "true". No Slack notification sent.'
                   else
-                    curl -X POST -H 'Content-type: application/json' --data "{ \"attachments\": [ { \"fallback\": \"A job has succeeded - $CIRCLE_BUILD_URL\", \"text\": \":tada: A $CIRCLE_JOB job has succeeded! $SLACK_MENTIONS\", \"fields\": [ { \"title\": \"Project\", \"value\": \"$CIRCLE_PROJECT_REPONAME\", \"short\": true }, { \"title\": \"Job Number\", \"value\": \"$CIRCLE_BUILD_NUM\", \"short\": true } ], \"actions\": [ { \"type\": \"button\", \"text\": \"Visit Job\", \"url\": \"$CIRCLE_BUILD_URL\" } ], \"color\": \"#1CBF43\" } ] } " << parameters.webhook >>
+                    curl -X POST -H 'Content-type: application/json' \
+                      --data "{ \
+                                \"attachments\": [ \
+                                  { \
+                                    \"fallback\": \"A job has succeeded - $CIRCLE_BUILD_URL\", \
+                                    \"text\": \":tada: A $CIRCLE_JOB job has succeeded! $SLACK_MENTIONS\", \
+                                    \"fields\": [ \
+                                      { \
+                                        \"title\": \"Project\", \
+                                        \"value\": \"$CIRCLE_PROJECT_REPONAME\", \
+                                        \"short\": true \
+                                      }, { \
+                                        \"title\": \"Job Number\", \
+                                        \"value\": \"$CIRCLE_BUILD_NUM\", \
+                                        \"short\": true \
+                                      } \
+                                    ], \
+                                    \"actions\": [ \
+                                      { \
+                                        \"type\": \"button\", \
+                                        \"text\": \"Visit Job\", \
+                                        \"url\": \"$CIRCLE_BUILD_URL\" \
+                                      } \
+                                    ], \
+                                    \"color\": \"#1CBF43\" \
+                                  } \
+                                ] \
+                              } " << parameters.webhook >>
                     echo "Job completed successfully. Alert sent."
                   fi
                 else
                   #If Failed
-                  curl -X POST -H 'Content-type: application/json' --data "{ \"attachments\": [ { \"fallback\": \"A job has failed - $CIRCLE_BUILD_URL\", \"text\": \":red_circle: A $CIRCLE_JOB job has failed! $SLACK_MENTIONS\", \"fields\": [ { \"title\": \"Project\", \"value\": \"$CIRCLE_PROJECT_REPONAME\", \"short\": true }, { \"title\": \"Job Number\", \"value\": \"$CIRCLE_BUILD_NUM\", \"short\": true } ], \"actions\": [ { \"type\": \"button\", \"text\": \"Visit Job\", \"url\": \"$CIRCLE_BUILD_URL\" } ], \"color\": \"#ed5c5c\" } ] } " << parameters.webhook >>
+                  curl -X POST -H 'Content-type: application/json' \
+                    --data "{ \
+                      \"attachments\": [ \
+                        { \
+                          \"fallback\": \"A job has failed - $CIRCLE_BUILD_URL\", \
+                          \"text\": \":red_circle: A $CIRCLE_JOB job has failed! $SLACK_MENTIONS\", \
+                          \"fields\": [ \
+                            { \
+                              \"title\": \"Project\", \
+                              \"value\": \"$CIRCLE_PROJECT_REPONAME\", \
+                              \"short\": true \
+                            }, { \
+                              \"title\": \"Job Number\", \
+                              \"value\": \"$CIRCLE_BUILD_NUM\", \
+                              \"short\": true \
+                            } \
+                          ], \
+                          \"actions\": [ \
+                            { \
+                              \"type\": \"button\", \
+                              \"text\": \"Visit Job\", \
+                              \"url\": \"$CIRCLE_BUILD_URL\" \
+                            } \
+                          ], \
+                          \"color\": \"#ed5c5c\" \
+                        } \
+                      ] \
+                    } " << parameters.webhook >>
                   echo "Job failed. Alert sent."
                 fi
               fi


### PR DESCRIPTION
at the moment, the curl commands that invoke the slack API are formatted as a single-line command, making it harder to read / follow, especially with all the escaped quotes, etc. 

I think splitting this into multi-line, properly-indented json makes it much easier to follow / maintain / spot any issues.