### PR TITLE
Add parameter which only for tag to status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See Slack's [Basic message formatting](https://api.slack.com/docs/message-format
 |  Usage | slack/status   |
 | ------------ | ------------ |
 | **Description:** | Send a status alert at the end of a job based on success or failure. This must be the last step in a job. |
-|  **Parameters:** | -  **webhook:** Enter either your Webhook value or use the CircleCI UI to add your token under the `SLACK_WEBHOOK` environment variable <br> <br> - **fail_only:** `false` by default. If set to `true, successful jobs will _not_ send alerts <br> <br> - **mentions:**  comma separated list of Slack user IDs, or Group (SubTeam) IDs. example 'USER1,USER2,USER3'. Note, these are Slack User IDs, not usernames. The user ID can be found on the user's profile. Look below for infomration on obtaining Group ID. <br> <br> - **only_for_branch**: Optional: If set, a specific branch for which status updates will be sent. |
+|  **Parameters:** | -  **webhook:** Enter either your Webhook value or use the CircleCI UI to add your token under the `SLACK_WEBHOOK` environment variable <br> <br> - **fail_only:** `false` by default. If set to `true, successful jobs will _not_ send alerts <br> <br> - **mentions:**  comma separated list of Slack user IDs, or Group (SubTeam) IDs. example 'USER1,USER2,USER3'. Note, these are Slack User IDs, not usernames. The user ID can be found on the user's profile. Look below for infomration on obtaining Group ID. <br> <br> - **only_for_branch**: Optional: If set, a specific branch for which status updates will be sent. <br> <br> - **only_for_tag**: Optional: If set, status updates will be sent to any tag. |
 
 Example:
 
@@ -85,6 +85,7 @@ jobs:
           fail_only: "true" # Optional: if set to "true" then only failure messages will occur.
           webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
           only_for_branch: "master" # Optional: If set, a specific branch for which status updates will be sent. In this case, only for pushes to master branch.
+          only_for_tag: true # Optional: If set, status updates will be sent to any tag. In this case, only for pushes to any tag.
 ```
 
 ![Status Success Example](/img/statusSuccess.PNG)

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -54,9 +54,9 @@ steps:
       shell: /bin/bash
       when: always
       command: |
-        if [[ "x" == "x<< parameters.only_for_branch >>" && "${CIRCLE_BRANCH}" == "<< parameters.only_for_branch >>" ]] ||
-           << parameters.only_for_tag >> && [ -n "${CIRCLE_TAG}" ] ||
-           [[ -z "<< parameters.only_for_branch >>" && ! << parameters.only_for_tag >> ]]; then
+        if [[ -n "${CIRCLE_BRANCH}" && "x" == "x<< parameters.only_for_branch >>" && "${CIRCLE_BRANCH}" == "<< parameters.only_for_branch >>" ]] ||
+           [[ -n "${CIRCLE_TAG}" && "xtrue" == "x<< parameters.only_for_tag >>" ]] ||
+           [[ "x" == "x<< parameters.only_for_branch >>" && "x" == "x<< parameters.only_for_tag >>" ]]; then
           # Provide error if no webhook is set and error. Otherwise continue
           if [ -z "<< parameters.webhook >>" ]; then
             echo "NO SLACK WEBHOOK SET"

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -19,9 +19,14 @@ parameters:
     default: ""
 
   only_for_branch:
-    description: If, set, a specific branch for which slack status updates will be sent.
+    description: If set, a specific branch for which slack status updates will be sent.
     type: string
     default: ""
+
+  only_for_tag:
+    description: If set, status updates will be sent to any tag.
+    type: boolean
+    default: false
 
 steps:
   - run:
@@ -49,7 +54,9 @@ steps:
       shell: /bin/bash
       when: always
       command: |
-        if [ "x" == "x<< parameters.only_for_branch>>" ] || [ "${CIRCLE_BRANCH}" == "<< parameters.only_for_branch>>" ]; then
+        if [[ "x" == "x<< parameters.only_for_branch >>" && "${CIRCLE_BRANCH}" == "<< parameters.only_for_branch >>" ]] ||
+           << parameters.only_for_tag >> && [ -n "${CIRCLE_TAG}" ] ||
+           [[ -z "<< parameters.only_for_branch >>" && ! << parameters.only_for_tag >> ]]; then
           # Provide error if no webhook is set and error. Otherwise continue
           if [ -z "<< parameters.webhook >>" ]; then
             echo "NO SLACK WEBHOOK SET"

--- a/src/examples/status.yml
+++ b/src/examples/status.yml
@@ -19,3 +19,4 @@ usage:
             fail_only: "true" # Optional: if set to "true" then only failure messages will occur.
             webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
             only_for_branch: "only_for_branch" # Optional: If set, a specific branch for which status updates will be sent.
+            only_for_tag: true # Optional: If set, status updates will be sent to any tag.


### PR DESCRIPTION
### Checklist
- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Description
Added a new parameter - only_for_tag - to the slack/status command, which allows slack updates to be triggered for builds on any tag only.