### PR TITLE
Add `when` attribute for `slack/notify` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Notify a slack channel with a custom message at any point in a job with this cus
 | `include_project_field` | `boolean` | `true` | Whether or not to include the _Project_ field in the message |
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
 | `include_visit_job_action` | `boolean` | `true` | Whether or not to include the _Visit Job_ action in the message |
+| `when` | `string` |  | When to send the notification, can be `on_success` or `on_fail`. |
 
 [Slack message attachment]: https://api.slack.com/docs/message-attachments
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Notify a slack channel with a custom message at any point in a job with this cus
 | `include_project_field` | `boolean` | `true` | Whether or not to include the _Project_ field in the message |
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
 | `include_visit_job_action` | `boolean` | `true` | Whether or not to include the _Visit Job_ action in the message |
-| `when` | `string` |  | When to send the notification, can be `on_success` or `on_fail`. |
+| `when` | `enum` |  | When to send the notification, must be one of: `always`, `on_success`, `on_fail`, defaults to `always`.  |
 
 [Slack message attachment]: https://api.slack.com/docs/message-attachments
 
@@ -65,7 +65,7 @@ jobs:
           mentions: "USERID1,USERID2," # Optional: Enter the Slack IDs of any user or group (sub_team) to be mentioned
           color: "#42e2f4" # Optional: Assign custom colors for each notification
           webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
-          when: "on_success" # Optional: Can be `on_success` or `on_fail`
+          when: "always" # Optional: Must be one of `always`, `on_success`, `on_fail`
 ```
 
 ![Custom Message Example](/img/notifyMessage.PNG)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ jobs:
           mentions: "USERID1,USERID2," # Optional: Enter the Slack IDs of any user or group (sub_team) to be mentioned
           color: "#42e2f4" # Optional: Assign custom colors for each notification
           webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
+          when: "on_success" # Optional: Can be `on_success` or `on_fail`
 ```
 
 ![Custom Message Example](/img/notifyMessage.PNG)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ jobs:
           mentions: "USERID1,USERID2," # Optional: Enter the Slack IDs of any user or group (sub_team) to be mentioned
           color: "#42e2f4" # Optional: Assign custom colors for each notification
           webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
-          when: "always" # Optional: Must be one of `always`, `on_success`, `on_fail`
+          when: "always" # Optional: Must be one of `always`, `on_success`, `on_fail` or the default will use `always`
 ```
 
 ![Custom Message Example](/img/notifyMessage.PNG)

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -75,13 +75,13 @@ steps:
   - run:
       name: Slack - Setting Failure Condition
       command: |
-        echo 'export SLACK_BUILD_STATUS="on_fail"' >> $BASH_ENV
+        echo 'export CIRCLE_BUILD_STATUS="on_fail"' >> $BASH_ENV
       when: on_fail
 
   - run:
       name: Slack - Setting Success Condition
       command: |
-        echo 'export SLACK_BUILD_STATUS="on_success"' >> $BASH_ENV
+        echo 'export CIRCLE_BUILD_STATUS="on_success"' >> $BASH_ENV
       when: on_success
 
   - run:
@@ -103,7 +103,7 @@ steps:
           exit 1
         else
           if [ -n "<< parameters.when >>" ]; then
-            if [ << parameters.when >> != $SLACK_BUILD_STATUS ]; then
+            if [ << parameters.when >> != $CIRCLE_BUILD_STATUS ]; then
               exit 0
             fi
           fi

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -67,7 +67,7 @@ parameters:
     default: true
 
   when:
-    description: When to send the notification, must be one of: `always`, `on_success` or `on_fail`.
+    description: When to send the notification, must be one of `always`, `on_success` or `on_fail`.
     type: enum
     default: "always"
     enum: ["always", "on_fail", "on_success"]

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -14,42 +14,42 @@ parameters:
   color:
     description: Hex color value for notification attachment color.
     type: string
-    default: '#333333'
+    default: "#333333"
 
   mentions:
     description: A comma separated list of user IDs. No spaces.
     type: string
-    default: ''
+    default: ""
 
   author_name:
     description: Optional author name
     type: string
-    default: ''
+    default: ""
 
   author_link:
     description: Optional author link
     type: string
-    default: ''
+    default: ""
 
   title:
     description: Optional title
     type: string
-    default: ''
+    default: ""
 
   title_link:
     description: Optional title link
     type: string
-    default: ''
+    default: ""
 
   footer:
     description: Optional footer
     type: string
-    default: ''
+    default: ""
 
   ts:
     description: Optional timestamp
     type: string
-    default: ''
+    default: ""
 
   include_project_field:
     description: Whether or not to include the Project field in the message
@@ -67,9 +67,10 @@ parameters:
     default: true
 
   when:
-    description: When to send the notification, can be `on_success` or `on_fail`.
-    type: string
-    default: ''
+    description: When to send the notification, must be one of: `always`, `on_success` or `on_fail`.
+    type: enum
+    default: "always"
+    enum: ["always", "on_fail", "on_success"]
 
 steps:
   - run:

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -14,42 +14,42 @@ parameters:
   color:
     description: Hex color value for notification attachment color.
     type: string
-    default: "#333333"
+    default: '#333333'
 
   mentions:
     description: A comma separated list of user IDs. No spaces.
     type: string
-    default: ""
+    default: ''
 
   author_name:
     description: Optional author name
     type: string
-    default: ""
+    default: ''
 
   author_link:
     description: Optional author link
     type: string
-    default: ""
+    default: ''
 
   title:
     description: Optional title
     type: string
-    default: ""
+    default: ''
 
   title_link:
     description: Optional title link
     type: string
-    default: ""
+    default: ''
 
   footer:
     description: Optional footer
     type: string
-    default: ""
+    default: ''
 
   ts:
     description: Optional timestamp
     type: string
-    default: ""
+    default: ''
 
   include_project_field:
     description: Whether or not to include the Project field in the message
@@ -66,7 +66,24 @@ parameters:
     type: boolean
     default: true
 
+  when:
+    description: When to send the notification, can be `on_success` or `on_fail`.
+    type: string
+    default: ''
+
 steps:
+  - run:
+      name: Slack - Setting Failure Condition
+      command: |
+        echo 'export SLACK_BUILD_STATUS="on_fail"' >> $BASH_ENV
+      when: on_fail
+
+  - run:
+      name: Slack - Setting Success Condition
+      command: |
+        echo 'export SLACK_BUILD_STATUS="on_success"' >> $BASH_ENV
+      when: on_success
+
   - run:
       name: Provide error if non-bash shell
       command: |
@@ -85,6 +102,12 @@ steps:
           echo "Please input your SLACK_WEBHOOK value either in the settings for this project, or as a parameter for this orb."
           exit 1
         else
+          if [ -n "<< parameters.when >>" ]; then
+            if [ << parameters.when >> != $SLACK_BUILD_STATUS ]; then
+              exit 0
+            fi
+          fi
+
           # Webhook properly set.
           echo Notifying Slack Channel
           #Create Members string

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -103,7 +103,7 @@ steps:
           echo "Please input your SLACK_WEBHOOK value either in the settings for this project, or as a parameter for this orb."
           exit 1
         else
-          if [ -n "<< parameters.when >>" ]; then
+          if [[ -n "<< parameters.when >>" && << parameters.when >> != "always" ]]; then
             if [ << parameters.when >> != $CIRCLE_BUILD_STATUS ]; then
               exit 0
             fi

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -73,13 +73,13 @@ parameters:
 
 steps:
   - run:
-      name: Slack - Setting Failure Condition
+      name: Circle - Setting Failure Condition
       command: |
         echo 'export CIRCLE_BUILD_STATUS="on_fail"' >> $BASH_ENV
       when: on_fail
 
   - run:
-      name: Slack - Setting Success Condition
+      name: Circle - Setting Success Condition
       command: |
         echo 'export CIRCLE_BUILD_STATUS="on_success"' >> $BASH_ENV
       when: on_success

--- a/src/examples/notify.yml
+++ b/src/examples/notify.yml
@@ -16,7 +16,7 @@ usage:
             mentions: "USERID1,USERID2," # Optional: Enter the Slack IDs of any user or group (sub_team) to be mentioned
             color: "#42e2f4" # Optional: Assign custom colors for each notification
             webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
-            when: "on_success" # Optional: Can be `on_success` or `on_fail`
+            when: "always" # Optional: Must be one of `always`, `on_success` or `on_fail`
 
   workflows:
     your-workflow:

--- a/src/examples/notify.yml
+++ b/src/examples/notify.yml
@@ -16,7 +16,7 @@ usage:
             mentions: "USERID1,USERID2," # Optional: Enter the Slack IDs of any user or group (sub_team) to be mentioned
             color: "#42e2f4" # Optional: Assign custom colors for each notification
             webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
-	    when: "on_success" # Optional: Can be `on_success` or `on_fail`
+            when: "on_success" # Optional: Can be `on_success` or `on_fail`
 
   workflows:
     your-workflow:

--- a/src/examples/notify.yml
+++ b/src/examples/notify.yml
@@ -16,6 +16,7 @@ usage:
             mentions: "USERID1,USERID2," # Optional: Enter the Slack IDs of any user or group (sub_team) to be mentioned
             color: "#42e2f4" # Optional: Assign custom colors for each notification
             webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
+	    when: "on_success" # Optional: Can be `on_success` or `on_fail`
 
   workflows:
     your-workflow:


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Related issue: https://github.com/CircleCI-Public/slack-orb/issues/33

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

This PR is to introduce `when` attribute to `slack/notify` so that users can freely decide when to send the notification based on CircleCI's job status.