### PR TITLE
Copy include_* options from notify to status

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Send a status alert at the end of a job based on success or failure. This must b
 | `mentions` | `string` |  | Comma-separated list of Slack User or Group (SubTeam) IDs (e.g., "USER1,USER2,USER3"). _**Note:** these are Slack User IDs, not usernames. The user ID can be found on the user's profile. Look below for information on obtaining Group ID._ |
 | `fail_only` | `string` | false | If set to "true," successful jobs will _not_ send alerts |
 | `only_for_branch` | `string` |  | If set, a specific branch for which slack status updates will be sent |
+| `include_project_field` | `boolean` | `true` | Whether or not to include the _Project_ field in the message |
+| `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
+| `include_visit_job_action` | `boolean` | `true` | Whether or not to include the _Visit Job_ action in the message |
 
 Example:
 

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -33,6 +33,21 @@ parameters:
     type: string
     default: ""
 
+  include_project_field:
+    description: Whether or not to include the Project field in the message
+    type: boolean
+    default: true
+
+  include_job_number_field:
+    description: Whether or not to include the Job Number field in the message
+    type: boolean
+    default: true
+
+  include_visit_job_action:
+    description: Whether or not to include the Visit Job action in the message
+    type: boolean
+    default: true
+
 steps:
   - run:
       name: Slack - Setting Failure Condition
@@ -91,22 +106,29 @@ steps:
                                 \"fallback\": \"A job has succeeded - $CIRCLE_BUILD_URL\", \
                                 \"text\": \"<< parameters.success_message >>\", \
                                 \"fields\": [ \
+                                  <<# parameters.include_project_field >>
                                   { \
                                     \"title\": \"Project\", \
                                     \"value\": \"$CIRCLE_PROJECT_REPONAME\", \
                                     \"short\": true \
-                                  }, { \
+                                  }, \
+                                  <</ parameters.include_project_field >>
+                                  <<# parameters.include_job_number_field >>
+                                  { \
                                     \"title\": \"Job Number\", \
                                     \"value\": \"$CIRCLE_BUILD_NUM\", \
                                     \"short\": true \
                                   } \
+                                  <</ parameters.include_job_number_field >>
                                 ], \
                                 \"actions\": [ \
+                                  <<# parameters.include_visit_job_action >>
                                   { \
                                     \"type\": \"button\", \
                                     \"text\": \"Visit Job\", \
                                     \"url\": \"$CIRCLE_BUILD_URL\" \
                                   } \
+                                  <</ parameters.include_visit_job_action >>
                                 ], \
                                 \"color\": \"#1CBF43\" \
                               } \
@@ -123,22 +145,29 @@ steps:
                       \"fallback\": \"A job has failed - $CIRCLE_BUILD_URL\", \
                       \"text\": \"<< parameters.failure_message >>\", \
                       \"fields\": [ \
+                        <<# parameters.include_project_field >>
                         { \
                           \"title\": \"Project\", \
                           \"value\": \"$CIRCLE_PROJECT_REPONAME\", \
                           \"short\": true \
-                        }, { \
+                        }, \
+                        <</ parameters.include_project_field >>
+                        <<# parameters.include_job_number_field >>
+                        { \
                           \"title\": \"Job Number\", \
                           \"value\": \"$CIRCLE_BUILD_NUM\", \
                           \"short\": true \
                         } \
+                        <</ parameters.include_job_number_field >>
                       ], \
                       \"actions\": [ \
+                        <<# parameters.include_visit_job_action >>
                         { \
                           \"type\": \"button\", \
                           \"text\": \"Visit Job\", \
                           \"url\": \"$CIRCLE_BUILD_URL\" \
                         } \
+                        <</ parameters.include_visit_job_action >>
                       ], \
                       \"color\": \"#ed5c5c\" \
                     } \


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

We do a lot of deployments across a lot of environments and while the status updates are valuable, they are currently very verbose. We would like them to fit on a single line.

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

Copied include_* from notify to status command