### PR TITLE
Support custom success/failure messages for slack/status

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Send a status alert at the end of a job based on success or failure. This must b
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `webhook` | `string` | ${SLACK_WEBHOOK} | Enter either your webhook value or use the CircleCI UI to add your token under the `SLACK_WEBHOOK` environment variable |
+| `success_message` | `string` | :tada: A $CIRCLE_JOB job has succeeded! $SLACK_MENTIONS | Enter your custom message to send to your Slack channel |
+| `failure_message` | `string` | :red_circle: A $CIRCLE_JOB job has failed! $SLACK_MENTIONS | Enter your custom message to send to your Slack channel |
 | `mentions` | `string` |  | Comma-separated list of Slack User or Group (SubTeam) IDs (e.g., "USER1,USER2,USER3"). _**Note:** these are Slack User IDs, not usernames. The user ID can be found on the user's profile. Look below for information on obtaining Group ID._ |
 | `fail_only` | `string` | false | If set to "true," successful jobs will _not_ send alerts |
 | `only_for_branch` | `string` |  | If set, a specific branch for which slack status updates will be sent |

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -8,6 +8,16 @@ parameters:
     type: string
     default: ${SLACK_WEBHOOK}
 
+  success_message:
+    description: Enter custom message.
+    type: string
+    default: :tada: A $CIRCLE_JOB job has succeeded! $SLACK_MENTIONS
+
+  failure_message:
+    description: Enter custom message.
+    type: string
+    default: :red_circle: A $CIRCLE_JOB job has failed! $SLACK_MENTIONS
+
   fail_only:
     description: If 'true', notifications successful jobs will not be sent
     type: string
@@ -79,7 +89,7 @@ steps:
                             \"attachments\": [ \
                               { \
                                 \"fallback\": \"A job has succeeded - $CIRCLE_BUILD_URL\", \
-                                \"text\": \":tada: A $CIRCLE_JOB job has succeeded! $SLACK_MENTIONS\", \
+                                \"text\": \"<< parameters.success_message >>\", \
                                 \"fields\": [ \
                                   { \
                                     \"title\": \"Project\", \
@@ -111,7 +121,7 @@ steps:
                   \"attachments\": [ \
                     { \
                       \"fallback\": \"A job has failed - $CIRCLE_BUILD_URL\", \
-                      \"text\": \":red_circle: A $CIRCLE_JOB job has failed! $SLACK_MENTIONS\", \
+                      \"text\": \"<< parameters.failure_message >>\", \
                       \"fields\": [ \
                         { \
                           \"title\": \"Project\", \


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

We want to use project name rather than $CIRCLE_JOB in our messages.

Also see issue #33 where @cayter says they want custom messages for the status command.

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Add new `success_message` and `failure_message` parameters to `status` command, defaulting to existing hardcoded values for those messages.