### PR TITLE
[Stuck] only_for_branch on notify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,16 @@ jobs:
           color: "#f4aa42"
           mentions: "${ORBS_USER_GROUP_UUID}"
 
+  notifymastertest:
+    executor: ci-base
+    steps:
+      - run: exit 0 #toggle this to force success or status for testing
+      - slack/notify:
+          message: "notification test for the Slack orb, triggered by *<https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/commit/${CIRCLE_SHA1}|commit ${CIRCLE_SHA1}>* on ${CIRCLE_PROJECT_REPONAME}'s *${CIRCLE_BRANCH}* branch (<https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}|workflow here>)"
+          color: "#f4aa42"
+          mentions: "${ORBS_USER_GROUP_UUID}"
+          only_for_branch: "master"
+
   statustestpass:
     executor: ci-base
     steps:
@@ -127,6 +137,11 @@ workflows:
       # triggered by master branch commits
       - notifytest:
           name: notifytest-master
+          context: orb-publishing
+          filters: *integration-master_filters
+      
+      - notifymastertest:
+          name: notifymastertest-master
           context: orb-publishing
           filters: *integration-master_filters
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Notify a slack channel with a custom message at any point in a job with this cus
 | `include_project_field` | `boolean` | `true` | Whether or not to include the _Project_ field in the message |
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
 | `include_visit_job_action` | `boolean` | `true` | Whether or not to include the _Visit Job_ action in the message |
+| `only_for_branch` | `string` |  | If set, a specific branch for which slack notify messages will be sent |
 
 [Slack message attachment]: https://api.slack.com/docs/message-attachments
 
@@ -64,6 +65,7 @@ jobs:
           mentions: "USERID1,USERID2," # Optional: Enter the Slack IDs of any user or group (sub_team) to be mentioned
           color: "#42e2f4" # Optional: Assign custom colors for each notification
           webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
+          only_for_branch: "master" # Optional: If set, a specific branch for which status updates will be sent. In this case, only for pushes to master branch.
 ```
 
 ![Custom Message Example](/img/notifyMessage.PNG)

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -65,6 +65,11 @@ parameters:
     description: Whether or not to include the Visit Job action in the message
     type: boolean
     default: true
+  
+  only_for_branch:
+    description: If, set, a specific branch for which slack notifcations will be sent.
+    type: string
+    default: ""
 
 steps:
   - run:
@@ -79,65 +84,67 @@ steps:
       name: Slack Notification
       shell: /bin/bash
       command: |
-        # Provide error if no webhook is set and error. Otherwise continue
-        if [ -z "<< parameters.webhook >>" ]; then
-          echo "NO SLACK WEBHOOK SET"
-          echo "Please input your SLACK_WEBHOOK value either in the settings for this project, or as a parameter for this orb."
-          exit 1
-        else
-          # Webhook properly set.
-          echo Notifying Slack Channel
-          #Create Members string
-          if [ -n "<< parameters.mentions >>" ]; then
-            IFS="," read -ra SLACK_MEMBERS \<<< "<< parameters.mentions >>"
-            for i in "${SLACK_MEMBERS[@]}"; do
-              if [ $(echo ${i} | head -c 1) == "S" ]; then
-                SLACK_MENTIONS="${SLACK_MENTIONS}<!subteam^${i}> "
-              else
-                SLACK_MENTIONS="${SLACK_MENTIONS}<@${i}> "
-              fi
-            done
+        if [ "x" == "x<< parameters.only_for_branch>>" ] || [ "${CIRCLE_BRANCH}" == "<< parameters.only_for_branch>>" ]; then
+          # Provide error if no webhook is set and error. Otherwise continue
+          if [ -z "<< parameters.webhook >>" ]; then
+            echo "NO SLACK WEBHOOK SET"
+            echo "Please input your SLACK_WEBHOOK value either in the settings for this project, or as a parameter for this orb."
+            exit 1
+          else
+            # Webhook properly set.
+            echo Notifying Slack Channel
+            #Create Members string
+            if [ -n "<< parameters.mentions >>" ]; then
+              IFS="," read -ra SLACK_MEMBERS \<<< "<< parameters.mentions >>"
+              for i in "${SLACK_MEMBERS[@]}"; do
+                if [ $(echo ${i} | head -c 1) == "S" ]; then
+                  SLACK_MENTIONS="${SLACK_MENTIONS}<!subteam^${i}> "
+                else
+                  SLACK_MENTIONS="${SLACK_MENTIONS}<@${i}> "
+                fi
+              done
+            fi
+            curl -X POST -H 'Content-type: application/json' \
+              --data \
+              "{ \
+                \"attachments\": [ \
+                  { \
+                    \"fallback\": \"<< parameters.message >> - $CIRCLE_BUILD_URL\", \
+                    \"text\": \"<< parameters.message >> $SLACK_MENTIONS\", \
+                    \"author_name\": \"<< parameters.author_name >>\", \
+                    \"author_link\": \"<< parameters.author_link >>\", \
+                    \"title\": \"<< parameters.title >>\", \
+                    \"title_link\": \"<< parameters.title_link >>\", \
+                    \"footer\": \"<< parameters.footer >>\", \
+                    \"ts\": \"<< parameters.ts >>\", \
+                    \"fields\": [ \
+                      <<# parameters.include_project_field >>
+                      { \
+                        \"title\": \"Project\", \
+                        \"value\": \"$CIRCLE_PROJECT_REPONAME\", \
+                        \"short\": true \
+                      }, \
+                      <</ parameters.include_project_field >>
+                      <<# parameters.include_job_number_field >>
+                      { \
+                        \"title\": \"Job Number\", \
+                        \"value\": \"$CIRCLE_BUILD_NUM\", \
+                        \"short\": true \
+                      } \
+                      <</ parameters.include_job_number_field >>
+                    ], \
+                    \"actions\": [ \
+                      <<# parameters.include_visit_job_action >>
+                      { \
+                        \"type\": \"button\", \
+                        \"text\": \"Visit Job\", \
+                        \"url\": \"$CIRCLE_BUILD_URL\" \
+                      } \
+                      <</ parameters.include_visit_job_action >>
+                    ], \
+                    \"color\": \"<< parameters.color >>\" \
+                  } \
+                ] \
+              }" << parameters.webhook >>
           fi
-          curl -X POST -H 'Content-type: application/json' \
-            --data \
-            "{ \
-              \"attachments\": [ \
-                { \
-                  \"fallback\": \"<< parameters.message >> - $CIRCLE_BUILD_URL\", \
-                  \"text\": \"<< parameters.message >> $SLACK_MENTIONS\", \
-                  \"author_name\": \"<< parameters.author_name >>\", \
-                  \"author_link\": \"<< parameters.author_link >>\", \
-                  \"title\": \"<< parameters.title >>\", \
-                  \"title_link\": \"<< parameters.title_link >>\", \
-                  \"footer\": \"<< parameters.footer >>\", \
-                  \"ts\": \"<< parameters.ts >>\", \
-                  \"fields\": [ \
-                    <<# parameters.include_project_field >>
-                    { \
-                      \"title\": \"Project\", \
-                      \"value\": \"$CIRCLE_PROJECT_REPONAME\", \
-                      \"short\": true \
-                    }, \
-                    <</ parameters.include_project_field >>
-                    <<# parameters.include_job_number_field >>
-                    { \
-                      \"title\": \"Job Number\", \
-                      \"value\": \"$CIRCLE_BUILD_NUM\", \
-                      \"short\": true \
-                    } \
-                    <</ parameters.include_job_number_field >>
-                  ], \
-                  \"actions\": [ \
-                    <<# parameters.include_visit_job_action >>
-                    { \
-                      \"type\": \"button\", \
-                      \"text\": \"Visit Job\", \
-                      \"url\": \"$CIRCLE_BUILD_URL\" \
-                    } \
-                    <</ parameters.include_visit_job_action >>
-                  ], \
-                  \"color\": \"<< parameters.color >>\" \
-                } \
-              ] \
-            }" << parameters.webhook >>
         fi


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

I want to only `notify` things on master branch.
I saw someone else make a PR that added it to `status`

### Description

I got kinda stuck on the test. I can't seem to get my CI to work and I have spent too much time on it. 
Rather than scrap the whole thing, I thought I would post it to see if someone can help.
I can update the description or open a new PR if someone can help me test this/fix it.

