### PR TITLE
Support here,channel,everyone mentions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,7 @@ prod-deploy_requires: &prod-deploy_requires
     statustestpass-full-master,
     statustestpass-minimal-master,
     approvaltest-master,
+    approvaltest-mention-here-master,
     approval-notification-job-master
   ]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,12 @@ jobs:
       - slack/approval:
           mentions: "${ORBS_USER_GROUP_UUID}"
 
+  approvaltest-mention-here:
+    executor: ci-base
+    steps:
+      - slack/approval:
+          mentions: "here"
+
 # yaml anchor filters
 integration-dev_filters: &integration-dev_filters
   branches:
@@ -132,6 +138,11 @@ workflows:
           context: orb-publishing
           filters: *integration-dev_filters
 
+      - approvaltest-mention-here:
+          name: approvaltest-mention-here-dev
+          context: orb-publishing
+          filters: *integration-dev_filters
+
       - slack/approval-notification:
           name: approval-notification-job-dev
           context: orb-publishing
@@ -156,6 +167,11 @@ workflows:
 
       - approvaltest:
           name: approvaltest-master
+          context: orb-publishing
+          filters: *integration-master_filters
+
+      - approvaltest-mention-here:
+          name: approvaltest-mention-here-master
           context: orb-publishing
           filters: *integration-master_filters
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Notify a slack channel with a custom message at any point in a job with this cus
 |-----------|------|---------|-------------|
 | `webhook` | `string` | ${SLACK_WEBHOOK} | Enter either your webhook value or use the CircleCI UI to add your token under the `SLACK_WEBHOOK` environment variable |
 | `message` | `string` | Your job on CircleCI has completed. | Enter your custom message to send to your Slack channel |
-| `mentions` | `string` | `false` | Comma-separated list of Slack User or Group (SubTeam) IDs (e.g., "USER1,USER2,USER3"). _**Note:** these are Slack User IDs, not usernames. The user ID can be found on the user's profile. Look below for information on obtaining Group ID._ |
+| `mentions` | `string` | `false` | Comma-separated list of Slack User or Group (SubTeam) IDs (e.g., "USER1,USER2,USER3"). _**Note:** these are Slack User IDs, not usernames. The user ID can be found on the user's profile. Look below for information on obtaining Group ID. For `here`, `channel` or `everyone` just write them._ |
 | `color` | `string` | #333333 |  Hex color value for notification attachment color |
 | `author_name` | `string` |  | Optional author name property for the [Slack message attachment] |
 | `author_link` | `string` |  | Optional author link property for the [Slack message attachment] |

--- a/src/commands/approval.yml
+++ b/src/commands/approval.yml
@@ -56,6 +56,8 @@ steps:
             for i in "${SLACK_MEMBERS[@]}"; do
               if [ $(echo ${i} | head -c 1) == "S" ]; then
                 SLACK_MENTIONS="${SLACK_MENTIONS}<!subteam^${i}> "
+              elif echo ${i} | grep -E "here|channel|everyone" > /dev/null; then
+                SLACK_MENTIONS="${SLACK_MENTIONS}<!${i}> "
               else
                 SLACK_MENTIONS="${SLACK_MENTIONS}<@${i}> "
               fi

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -93,6 +93,8 @@ steps:
             for i in "${SLACK_MEMBERS[@]}"; do
               if [ $(echo ${i} | head -c 1) == "S" ]; then
                 SLACK_MENTIONS="${SLACK_MENTIONS}<!subteam^${i}> "
+              elif echo ${i} | grep -E "here|channel|everyone" > /dev/null; then
+                SLACK_MENTIONS="${SLACK_MENTIONS}<!${i}> "
               else
                 SLACK_MENTIONS="${SLACK_MENTIONS}<@${i}> "
               fi

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -87,6 +87,8 @@ steps:
               for i in "${SLACK_MEMBERS[@]}"; do
                 if [ $(echo ${i} | head -c 1) == "S" ]; then
                   SLACK_MENTIONS="${SLACK_MENTIONS}<!subteam^${i}> "
+                elif echo ${i} | grep -E "here|channel|everyone" > /dev/null; then
+                  SLACK_MENTIONS="${SLACK_MENTIONS}<!${i}> "
                 else
                   SLACK_MENTIONS="${SLACK_MENTIONS}<@${i}> "
                 fi


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

We want to use `@here` in mentions.

### Description
Add support for channel mentions: `@here`, `@channel` and `@everyone`.
