### PR TITLE
fix mentions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,12 @@ jobs:
       - slack/approval:
           mentions: "here"
 
+  approvaltest-mention-here-2:
+    executor: ci-base
+    steps:
+      - slack/approval:
+          mentions: "foo-here-bar"
+
 # yaml anchor filters
 integration-dev_filters: &integration-dev_filters
   branches:
@@ -69,6 +75,7 @@ prod-deploy_requires: &prod-deploy_requires
     statustestpass-minimal-master,
     approvaltest-master,
     approvaltest-mention-here-master,
+    approvaltest-mention-here-2-master,
     approval-notification-job-master
   ]
 
@@ -144,6 +151,11 @@ workflows:
           context: orb-publishing
           filters: *integration-dev_filters
 
+      - approvaltest-mention-here-2:
+          name: approvaltest-mention-here-2-dev
+          context: orb-publishing
+          filters: *integration-dev_filters
+
       - slack/approval-notification:
           name: approval-notification-job-dev
           context: orb-publishing
@@ -173,6 +185,11 @@ workflows:
 
       - approvaltest-mention-here:
           name: approvaltest-mention-here-master
+          context: orb-publishing
+          filters: *integration-master_filters
+
+      - approvaltest-mention-here-2:
+          name: approvaltest-mention-here-2-master
           context: orb-publishing
           filters: *integration-master_filters
 

--- a/src/commands/approval.yml
+++ b/src/commands/approval.yml
@@ -56,7 +56,7 @@ steps:
             for i in "${SLACK_MEMBERS[@]}"; do
               if [ $(echo ${i} | head -c 1) == "S" ]; then
                 SLACK_MENTIONS="${SLACK_MENTIONS}<!subteam^${i}> "
-              elif echo ${i} | grep -E "here|channel|everyone" > /dev/null; then
+              elif echo ${i} | grep -E "^(here|channel|everyone)$" > /dev/null; then
                 SLACK_MENTIONS="${SLACK_MENTIONS}<!${i}> "
               else
                 SLACK_MENTIONS="${SLACK_MENTIONS}<@${i}> "

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -93,7 +93,7 @@ steps:
             for i in "${SLACK_MEMBERS[@]}"; do
               if [ $(echo ${i} | head -c 1) == "S" ]; then
                 SLACK_MENTIONS="${SLACK_MENTIONS}<!subteam^${i}> "
-              elif echo ${i} | grep -E "here|channel|everyone" > /dev/null; then
+              elif echo ${i} | grep -E "^(here|channel|everyone)$" > /dev/null; then
                 SLACK_MENTIONS="${SLACK_MENTIONS}<!${i}> "
               else
                 SLACK_MENTIONS="${SLACK_MENTIONS}<@${i}> "

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -87,7 +87,7 @@ steps:
               for i in "${SLACK_MEMBERS[@]}"; do
                 if [ $(echo ${i} | head -c 1) == "S" ]; then
                   SLACK_MENTIONS="${SLACK_MENTIONS}<!subteam^${i}> "
-                elif echo ${i} | grep -E "here|channel|everyone" > /dev/null; then
+                elif echo ${i} | grep -E "^(here|channel|everyone)$" > /dev/null; then
                   SLACK_MENTIONS="${SLACK_MENTIONS}<!${i}> "
                 else
                   SLACK_MENTIONS="${SLACK_MENTIONS}<@${i}> "


### PR DESCRIPTION
### Checklist
- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
pull request #40 breaks normal mentions if slack user ids include `here`, `channel` or `everyone`.

### Description
- fix the pattern for `grep -E`.
- add a test.
