### PR TITLE
commands/status: Set success_message / failure_message to fallback field

### DIFF
--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -105,7 +105,7 @@ steps:
                   --data "{ \
                             \"attachments\": [ \
                               { \
-                                \"fallback\": \"A job has succeeded - $CIRCLE_BUILD_URL\", \
+                                \"fallback\": \"<< parameters.success_message >>\", \
                                 \"text\": \"<< parameters.success_message >>\", \
                                 \"fields\": [ \
                                   <<# parameters.include_project_field >>
@@ -144,7 +144,7 @@ steps:
                 --data "{ \
                   \"attachments\": [ \
                     { \
-                      \"fallback\": \"A job has failed - $CIRCLE_BUILD_URL\", \
+                      \"fallback\": \"<< parameters.failure_message >>\", \
                       \"text\": \"<< parameters.failure_message >>\", \
                       \"fields\": [ \
                         <<# parameters.include_project_field >>


### PR DESCRIPTION


### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Fixes #47

In the current implementation, using `failure_message` in status doesn't
affect the `fallback` field.
It causes a problem when sending a message to bots such as `hubot-slack`.
The `hubot-slack` parses the `fallback` field if a message has an attachment.

### Description

We should set `text` and `fallback` field to the same value.
The `success_message` also have the same issue. So I fixed both.

Any feedback is welcome!