### PR TITLE
Wrap `status` command with sensible defaults

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,6 +1,0 @@
-extends: relaxed
-
-rules:
-    line-length:
-        max: 200
-        allow-non-breakable-inline-mappings: true

--- a/publish-alpha.sh
+++ b/publish-alpha.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+circleci config pack src > orb.yml
+circleci orb publish orb.yml circleci/slack@dev:alpha
+rm -rf orb.yml

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 description: >
-  Easily integrate custom Slack notifications into your CircleCI projects. 
-  Create custom alert messages for any job or receive status updates. 
+  Easily integrate custom Slack notifications into your CircleCI projects.
+  Create custom alert messages for any job or receive status updates.
   View this orb's source: https://github.com/CircleCI-Public/slack-orb
 
 # Create your key here: https://api.slack.com/incoming-webhooks

--- a/src/commands/notify-on-failure.yml
+++ b/src/commands/notify-on-failure.yml
@@ -11,5 +11,5 @@ parameters:
 
 steps:
   - status:
-      fail_only: "true"
+      fail_only: true
       only_for_branch: <<parameters.only_for_branch>>

--- a/src/commands/notify-on-failure.yml
+++ b/src/commands/notify-on-failure.yml
@@ -1,13 +1,15 @@
-description: A handy command to notify a Slack channel on failure in the default master branch
+description: >
+  A handy command to notify a Slack channel on failure in the default
+  master branch
 
 parameters:
   only_for_branch:
-    description: If, set, a specific branch for which slack status updates will be sent.
     type: string
-    default: "master"
+    default: master
+    description: >
+      If set, a specific branch for which slack status updates will be sent
 
 steps:
-  - slack/status:
+  - status:
       fail_only: "true"
-      only_for_branch: << parameters.only_for_branch >>
-
+      only_for_branch: <<parameters.only_for_branch>>

--- a/src/commands/notify-on-failure.yml
+++ b/src/commands/notify-on-failure.yml
@@ -1,0 +1,13 @@
+description: A handy command to notify a Slack channel on failure in the default master branch
+
+parameters:
+  only_for_branch:
+    description: If, set, a specific branch for which slack status updates will be sent.
+    type: string
+    default: "master"
+
+steps:
+  - slack/status:
+      fail_only: "true"
+      only_for_branch: << parameters.only_for_branch >>
+

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -19,9 +19,9 @@ parameters:
     default: ":red_circle: A $CIRCLE_JOB job has failed! $SLACK_MENTIONS"
 
   fail_only:
-    description: If 'true', notifications successful jobs will not be sent
-    type: string
-    default: "false"
+    description: If `true`, notifications successful jobs will not be sent
+    type: boolean
+    default: false
 
   mentions:
     description: A comma separated list of user IDs. No spaces.

--- a/src/examples/status.yml
+++ b/src/examples/status.yml
@@ -16,6 +16,6 @@ usage:
 
         - slack/status:
             mentions: "USERID1,USERID2" # Optional: Enter the Slack IDs of any user or group (sub_team) to be mentioned
-            fail_only: "true" # Optional: if set to "true" then only failure messages will occur.
+            fail_only: true # Optional: if set to `true` then only failure messages will occur.
             webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
             only_for_branch: "only_for_branch" # Optional: If set, a specific branch for which status updates will be sent.


### PR DESCRIPTION
We use this command a lot, and everywhere we essentially repeat the
following over and over. It would be great if the orb just provided it
for us!

```
orbs:
  slack: circleci/slack@2.5.1

commands:
  # Wrap the slack/status command to only notify on failures
  slack-notify-on-failure:
    steps:
      - slack/status:
          fail_only: "true"
          only_for_branch: "master"
```

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
