### PR TITLE
Add mentions in custom messages of status command

### DIFF
--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -12,12 +12,12 @@ parameters:
 
   success_message:
     type: string
-    default: ":tada: A $CIRCLE_JOB job has succeeded! $SLACK_MENTIONS"
+    default: ":tada: A $CIRCLE_JOB job has succeeded!"
     description: Enter custom message.
 
   failure_message:
     type: string
-    default: ":red_circle: A $CIRCLE_JOB job has failed! $SLACK_MENTIONS"
+    default: ":red_circle: A $CIRCLE_JOB job has failed!"
     description: Enter custom message.
 
   fail_only:
@@ -125,7 +125,7 @@ steps:
                             \"attachments\": [ \
                               { \
                                 \"fallback\": \"<< parameters.success_message >>\", \
-                                \"text\": \"<< parameters.success_message >>\", \
+                                \"text\": \"<< parameters.success_message >> $SLACK_MENTIONS\", \
                                 \"fields\": [ \
                                   <<# parameters.include_project_field >>
                                   { \
@@ -164,7 +164,7 @@ steps:
                   \"attachments\": [ \
                     { \
                       \"fallback\": \"<< parameters.failure_message >>\", \
-                      \"text\": \"<< parameters.failure_message >>\", \
+                      \"text\": \"<< parameters.failure_message >> $SLACK_MENTIONS\", \
                       \"fields\": [ \
                         <<# parameters.include_project_field >>
                         { \


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

#64 

### Description

The `slack/status` command supports custom success/failure messages from #37, but currently these messages do not include the mentions while the default messages do. So this pull request fixes it to include the mentions in the custom messages as well.
