### PR TITLE
Fix bash check

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,11 @@ jobs:
 ## Dependencies / Requirements
 
 ### Bash Shell
-Due to the limitations of the `sh` shell, `Bash` is required. `Bash` is the default shell used on CircleCI and the Orb will be compatible with most images. Images such as `Alpine` that do not contain the `Bash` shell by default are incompatible and en error message will be logged. You may install the Bash shell through your package manager (example: `apk add bash`) in the Dockerfile for the image you are using.
+Because these scripts us bash-specific features, `Bash` is required.
+`Bash` is the default shell used on CircleCI and the Orb will be compatible with most images.
+If using an `Alpine` base image, you will need to call `apk add bash` before calling this Orb,
+or create a derivative base image that calls `RUN apk add bash`.
+If `Bash` is not available, an error message will be logged and the task will fail.
 
 ### cURL
 cURL is used to post the Webhook data and must be installed in the container to function properly.

--- a/src/commands/approval.yml
+++ b/src/commands/approval.yml
@@ -39,11 +39,6 @@ steps:
       name: Slack - Sending Approval Notification
       shell: /bin/bash
       command: |
-        # Provide error if non-bash shell
-        if [ ! -x /bin/bash ]; then
-          echo Bash not installed.
-          exit 1
-        fi
         # Provide error if no webhook is set and error. Otherwise continue
         if [ -z "<< parameters.webhook >>" ]; then
           echo "NO SLACK WEBHOOK SET"

--- a/src/commands/approval.yml
+++ b/src/commands/approval.yml
@@ -30,7 +30,7 @@ steps:
   - run:
       name: Provide error if non-bash shell
       command: |
-        if [ -z "$BASH" ]; then
+        if [ ! -x /bin/bash ]; then
           echo Bash not installed.
           exit 1
         fi
@@ -40,7 +40,7 @@ steps:
       shell: /bin/bash
       command: |
         # Provide error if non-bash shell
-        if [ -z "$BASH" ]; then
+        if [ ! -x /bin/bash ]; then
           echo Bash not installed.
           exit 1
         fi

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -70,7 +70,7 @@ steps:
   - run:
       name: Provide error if non-bash shell
       command: |
-        if [ -z "$BASH" ]; then
+        if [ ! -x /bin/bash ]; then
           echo Bash not installed.
           exit 1
         fi

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -73,7 +73,7 @@ steps:
   - run:
       name: Provide error if non-bash shell
       command: |
-        if [ -z "$BASH" ]; then
+        if [ ! -x /bin/bash ]; then
           echo Bash not installed.
           exit 1
         fi


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

This change solves #66 

### Description

Check for the existence of the required /bin/bash executable directly rather than trying to infer it from an env var named `$BASH` which will not be set in the `/bin/sh` shell on Alpline, and probably some other distros.

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
