### PR TITLE
Modified slack_webhook param type from string to env_var_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Notify a slack channel with a custom message at any point in a job with this cus
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `webhook` | `string` | ${SLACK_WEBHOOK} | Enter either your webhook value or use the CircleCI UI to add your token under the `SLACK_WEBHOOK` environment variable |
+| `webhook` | `env_var_name` | ${SLACK_WEBHOOK} | Please use the CircleCI UI to add your token under the `SLACK_WEBHOOK` environment variable |
 | `message` | `string` | Your job on CircleCI has completed. | Enter your custom message to send to your Slack channel |
 | `mentions` | `string` | `false` | Comma-separated list of Slack User or Group (SubTeam) IDs (e.g., "USER1,USER2,USER3"). _**Note:** these are Slack User IDs, not usernames. The user ID can be found on the user's profile. Look below for information on obtaining Group ID. For `here`, `channel` or `everyone` just write them._ |
 | `color` | `string` | #333333 |  Hex color value for notification attachment color |
@@ -64,7 +64,7 @@ jobs:
           message: "This is a custom message notification" # Optional: Enter your own message
           mentions: "USERID1,USERID2," # Optional: Enter the Slack IDs of any user or group (sub_team) to be mentioned
           color: "#42e2f4" # Optional: Assign custom colors for each notification
-          webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
+          webhook: ${SLACK_WEBHOOK} # Please use the CircleCI UI to set the slack webhook under the SLACK_WEBHOOK environment variable
 ```
 
 ![Custom Message Example](/img/notifyMessage.PNG)
@@ -76,7 +76,7 @@ Send a status alert at the end of a job based on success or failure. This must b
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `webhook` | `string` | ${SLACK_WEBHOOK} | Enter either your webhook value or use the CircleCI UI to add your token under the `SLACK_WEBHOOK` environment variable |
+| `webhook` | `env_var_name` | ${SLACK_WEBHOOK} | Please use the CircleCI UI to add your token under the `SLACK_WEBHOOK` environment variable |
 | `success_message` | `string` | :tada: A $CIRCLE_JOB job has succeeded! $SLACK_MENTIONS | Enter your custom message to send to your Slack channel |
 | `failure_message` | `string` | :red_circle: A $CIRCLE_JOB job has failed! $SLACK_MENTIONS | Enter your custom message to send to your Slack channel |
 | `mentions` | `string` |  | Comma-separated list of Slack User or Group (SubTeam) IDs (e.g., "USER1,USER2,USER3"). _**Note:** these are Slack User IDs, not usernames. The user ID can be found on the user's profile. Look below for information on obtaining Group ID._ |
@@ -106,7 +106,7 @@ jobs:
       - slack/status:
           mentions: "USERID1,USERID2" # Optional: Enter the Slack IDs of any user or group (sub_team) to be mentioned
           fail_only: true # Optional: if set to `true` then only failure messages will occur.
-          webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
+          webhook: ${SLACK_WEBHOOK} # Please use the CircleCI UI to set the slack webhook under the SLACK_WEBHOOK environment variable 
           only_for_branches: "master" # Optional: If set, a specific branch for which status updates will be sent. In this case, only for pushes to master branch.
 ```
 

--- a/src/commands/approval.yml
+++ b/src/commands/approval.yml
@@ -2,9 +2,9 @@ description: Send a notification that a manual approval job is ready
 
 parameters:
   webhook:
-    description: Enter either your Webhook value or use the CircleCI UI to add your token under the 'SLACK_WEBHOOK' env var
-    type: string
-    default: ${SLACK_WEBHOOK}
+    description: Please use the CircleCI UI to add your token under the 'SLACK_WEBHOOK' env var
+    type: env_var_name
+    default: SLACK_WEBHOOK
 
   message:
     description: Enter custom message.
@@ -48,7 +48,7 @@ steps:
         # Provide error if no webhook is set and error. Otherwise continue
         if [ -z "<< parameters.webhook >>" ]; then
           echo "NO SLACK WEBHOOK SET"
-          echo "Please input your SLACK_WEBHOOK value either in the settings for this project, or as a parameter for this orb."
+          echo "Please input your SLACK_WEBHOOK value in the settings for this project"
           exit 1
         else
           #Create Members string

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -2,9 +2,9 @@ description: Notify a Slack channel with a custom message
 
 parameters:
   webhook:
-    description: Enter either your Webhook value or use the CircleCI UI to add your token under the 'SLACK_WEBHOOK' env var
-    type: string
-    default: ${SLACK_WEBHOOK}
+    description: Please use the CircleCI UI to add your token under the 'SLACK_WEBHOOK' env var
+    type: env_var_name
+    default: SLACK_WEBHOOK
 
   message:
     description: Enter custom message.
@@ -88,7 +88,7 @@ steps:
         # Provide error if no webhook is set and error. Otherwise continue
         if [ -z "<< parameters.webhook >>" ]; then
           echo "NO SLACK WEBHOOK SET"
-          echo "Please input your SLACK_WEBHOOK value either in the settings for this project, or as a parameter for this orb."
+          echo "Please input your SLACK_WEBHOOK value in the settings for this project."
           exit 1
         else
           # Webhook properly set.

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -4,11 +4,11 @@ description: >
 
 parameters:
   webhook:
-    type: string
-    default: ${SLACK_WEBHOOK}
+    type: env_var_name
+    default: SLACK_WEBHOOK
     description: >
-      Enter either your Webhook value or use the CircleCI UI to add your
-      token under the 'SLACK_WEBHOOK' env var
+      Please use the CircleCI UI to add your token under the 
+      'SLACK_WEBHOOK' env var
 
   success_message:
     type: string
@@ -103,7 +103,7 @@ steps:
           # Provide error if no webhook is set and error. Otherwise continue
           if [ -z "<< parameters.webhook >>" ]; then
             echo "NO SLACK WEBHOOK SET"
-            echo "Please input your SLACK_WEBHOOK value either in the settings for this project, or as a parameter for this orb."
+            echo "Please input your SLACK_WEBHOOK value in the settings for this project"
             exit 1
           else
             #Create Members string

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -7,7 +7,7 @@ parameters:
     type: env_var_name
     default: SLACK_WEBHOOK
     description: >
-      Please use the CircleCI UI to add your token under the 
+      Please use the CircleCI UI to add your token under the
       'SLACK_WEBHOOK' env var
 
   success_message:

--- a/src/examples/approval.yml
+++ b/src/examples/approval.yml
@@ -11,4 +11,4 @@ usage:
       jobs:
         - slack/approval-notification:
             message: "Pending approval"
-            webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
+            webhook: ${SLACK_WEBHOOK} # Will use the value set in the CircleCI settings under the env-var SLACK_WEBHOOK

--- a/src/examples/notify.yml
+++ b/src/examples/notify.yml
@@ -15,7 +15,7 @@ usage:
             message: "This is a custom message notification" # Optional: Enter your own message
             mentions: "USERID1,USERID2," # Optional: Enter the Slack IDs of any user or group (sub_team) to be mentioned
             color: "#42e2f4" # Optional: Assign custom colors for each notification
-            webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
+            webhook: ${SLACK_WEBHOOK} # Will use the value set in the CircleCI settings under the env-var SLACK_WEBHOOK
             channel: "CHANNELID" # Optional: Enter a channel id to override webhook's default channel
 
   workflows:

--- a/src/examples/status.yml
+++ b/src/examples/status.yml
@@ -17,5 +17,5 @@ usage:
         - slack/status:
             mentions: "USERID1,USERID2" # Optional: Enter the Slack IDs of any user or group (sub_team) to be mentioned
             fail_only: true # Optional: if set to `true` then only failure messages will occur.
-            webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
+            webhook: ${SLACK_WEBHOOK} # Will use the value set in the CircleCI settings under the env-var SLACK_WEBHOOK
             only_for_branches: "only_for_branches" # Optional: If set, a comma-separated list of branches (or a single branch) for which status updates will be sent.

--- a/src/jobs/approval-notification.yml
+++ b/src/jobs/approval-notification.yml
@@ -2,9 +2,9 @@ description: Notify Slack about an awaiting approval job
 
 parameters:
   webhook:
-    description: Enter either your Webhook value or use the CircleCI UI to add your token under the 'SLACK_WEBHOOK' env var
-    type: string
-    default: ${SLACK_WEBHOOK}
+    description: Please use the CircleCI UI to add your token under the 'SLACK_WEBHOOK' env var
+    type: env_var_name
+    default: SLACK_WEBHOOK
 
   message:
     description: Enter custom message.


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
Closes #79 
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
The data type of slack webhook should be changed to env_var_name since the variable does not require user input once set and would be easy to manage using CircleCI env vars. Also this follows the best practices for orbs.
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
