### PR TITLE
fix(status-command):Added bash as the first check, before setting env…

### DIFF
--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -65,6 +65,14 @@ parameters:
 
 steps:
   - run:
+      name: Provide error if non-bash shell
+      command: |
+        if [ ! -x /bin/bash ]; then
+          echo Bash not installed.
+          exit 1
+        fi
+
+  - run:
       name: Slack - Setting Failure Condition
       command: |
         echo 'export SLACK_BUILD_STATUS="fail"' >> $BASH_ENV
@@ -75,14 +83,6 @@ steps:
       command: |
         echo 'export SLACK_BUILD_STATUS="success"' >> $BASH_ENV
       when: on_success
-
-  - run:
-      name: Provide error if non-bash shell
-      command: |
-        if [ ! -x /bin/bash ]; then
-          echo Bash not installed.
-          exit 1
-        fi
 
   - run:
       name: Slack - Sending Status Alert


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
Closes #84 
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
Modified flow of status command to check bash first before setting any environment variables.
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
