### PR TITLE
Add support for image_url on notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Notify a slack channel with a custom message at any point in a job with this cus
 |-----------|------|---------|-------------|
 | `webhook` | `string` | ${SLACK_WEBHOOK} | Enter either your webhook value or use the CircleCI UI to add your token under the `SLACK_WEBHOOK` environment variable |
 | `message` | `string` | Your job on CircleCI has completed. | Enter your custom message to send to your Slack channel |
+| `image_url` | `string` |  | Enter a valid URL to an image |
 | `mentions` | `string` | `false` | Comma-separated list of Slack User or Group (SubTeam) IDs (e.g., "USER1,USER2,USER3"). _**Note:** these are Slack User IDs, not usernames. The user ID can be found on the user's profile. Look below for information on obtaining Group ID. For `here`, `channel` or `everyone` just write them._ |
 | `color` | `string` | #333333 |  Hex color value for notification attachment color |
 | `author_name` | `string` |  | Optional author name property for the [Slack message attachment] |

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -11,6 +11,11 @@ parameters:
     type: string
     default: Your job on CircleCI has completed.
 
+  image_url:
+    description: Enter a valid Image URL
+    type: string
+    default: ""
+
   color:
     description: Hex color value for notification attachment color.
     type: string
@@ -129,6 +134,7 @@ steps:
                     } \
                     <</ parameters.include_job_number_field >>
                   ], \
+                  \"image_url\": \"<< parameters.image_url >>\", \
                   \"actions\": [ \
                     <<# parameters.include_visit_job_action >>
                     { \


### PR DESCRIPTION
Adds support for `image_url` passed to `notify` in order to attach an image to the notification message.

Reference CircleCI-Public/slack-orb#78

