### PR TITLE
Add parameters for incoming webhook's runtime customizations. #100

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Notify a slack channel with a custom message at any point in a job with this cus
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
 | `include_visit_job_action` | `boolean` | `true` | Whether or not to include the _Visit Job_ action in the message |
 | `channel` | `string` | | If set, overriding webhook's channel setting |
+| `username` | `string` | | If set, overriding webhook's username setting |
+| `icon_emoji` | `string` | | If set, overriding webhook's icon_emoji setting |
+| `icon_url` | `string` | | If set, overriding webhook's icon_url setting |
 
 [Slack message attachment]: https://api.slack.com/docs/message-attachments
 
@@ -86,6 +89,9 @@ Send a status alert at the end of a job based on success or failure. This must b
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
 | `include_visit_job_action` | `boolean` | `true` | Whether or not to include the _Visit Job_ action in the message |
 | `channel` | `string` | | If set, overriding webhook's channel setting |
+| `username` | `string` | | If set, overriding webhook's username setting |
+| `icon_emoji` | `string` | | If set, overriding webhook's icon_emoji setting |
+| `icon_url` | `string` | | If set, overriding webhook's icon_url setting |
 
 Example:
 

--- a/src/commands/approval.yml
+++ b/src/commands/approval.yml
@@ -32,6 +32,24 @@ parameters:
     description: >
       If set, overriding webhook's channel setting
 
+  username:
+    type: string
+    default: ""
+    description: >
+      If set, overriding webhook's username setting
+
+  icon_emoji:
+    type: string
+    default: ""
+    description: >
+      If set, overriding webhook's icon_emoji setting
+
+  icon_url:
+    type: string
+    default: ""
+    description: >
+      If set, overriding webhook's icon_url setting
+
 steps:
   - run:
       name: Provide error if non-bash shell
@@ -71,6 +89,15 @@ steps:
               <<# parameters.channel >>
               \"channel\": \"<< parameters.channel >>\", \
               <</ parameters.channel >>
+              <<# parameters.username >>
+              \"username\": \"<< parameters.username >>\", \
+              <</ parameters.username >>
+              <<# parameters.icon_emoji >>
+              \"icon_emoji\": \"<< parameters.icon_emoji >>\", \
+              <</ parameters.icon_emoji >>
+              <<# parameters.icon_url >>
+              \"icon_url\": \"<< parameters.icon_url >>\", \
+              <</ parameters.icon_url >>
               \"attachments\": [ \
                 { \
                   \"fallback\": \"<< parameters.message >> - << parameters.url >>\", \

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -72,6 +72,24 @@ parameters:
     description: >
       If set, overriding webhook's channel setting
 
+  username:
+    type: string
+    default: ""
+    description: >
+      If set, overriding webhook's username setting
+
+  icon_emoji:
+    type: string
+    default: ""
+    description: >
+      If set, overriding webhook's icon_emoji setting
+
+  icon_url:
+    type: string
+    default: ""
+    description: >
+      If set, overriding webhook's icon_url setting
+
 steps:
   - run:
       name: Provide error if non-bash shell
@@ -112,6 +130,15 @@ steps:
               <<# parameters.channel >>
               \"channel\": \"<< parameters.channel >>\", \
               <</ parameters.channel >>
+              <<# parameters.username >>
+              \"username\": \"<< parameters.username >>\", \
+              <</ parameters.username >>
+              <<# parameters.icon_emoji >>
+              \"icon_emoji\": \"<< parameters.icon_emoji >>\", \
+              <</ parameters.icon_emoji >>
+              <<# parameters.icon_url >>
+              \"icon_url\": \"<< parameters.icon_url >>\", \
+              <</ parameters.icon_url >>
               \"attachments\": [ \
                 { \
                   \"fallback\": \"<< parameters.message >> - $CIRCLE_BUILD_URL\", \

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -63,6 +63,24 @@ parameters:
     description: >
       If set, overriding webhook's channel setting
 
+  username:
+    type: string
+    default: ""
+    description: >
+      If set, overriding webhook's username setting
+
+  icon_emoji:
+    type: string
+    default: ""
+    description: >
+      If set, overriding webhook's icon_emoji setting
+
+  icon_url:
+    type: string
+    default: ""
+    description: >
+      If set, overriding webhook's icon_url setting
+
 steps:
   - run:
       name: Slack - Setting Failure Condition
@@ -131,6 +149,15 @@ steps:
                             <<# parameters.channel >>
                             \"channel\": \"<< parameters.channel >>\", \
                             <</ parameters.channel >>
+                            <<# parameters.username >>
+                            \"username\": \"<< parameters.username >>\", \
+                            <</ parameters.username >>
+                            <<# parameters.icon_emoji >>
+                            \"icon_emoji\": \"<< parameters.icon_emoji >>\", \
+                            <</ parameters.icon_emoji >>
+                            <<# parameters.icon_url >>
+                            \"icon_url\": \"<< parameters.icon_url >>\", \
+                            <</ parameters.icon_url >>
                             \"attachments\": [ \
                               { \
                                 \"fallback\": \"<< parameters.success_message >>\", \
@@ -173,6 +200,15 @@ steps:
                   <<# parameters.channel >>
                   \"channel\": \"<< parameters.channel >>\", \
                   <</ parameters.channel >>
+                  <<# parameters.username >>
+                  \"username\": \"<< parameters.username >>\", \
+                  <</ parameters.username >>
+                  <<# parameters.icon_emoji >>
+                  \"icon_emoji\": \"<< parameters.icon_emoji >>\", \
+                  <</ parameters.icon_emoji >>
+                  <<# parameters.icon_url >>
+                  \"icon_url\": \"<< parameters.icon_url >>\", \
+                  <</ parameters.icon_url >>
                   \"attachments\": [ \
                     { \
                       \"fallback\": \"<< parameters.failure_message >>\", \

--- a/src/examples/approval.yml
+++ b/src/examples/approval.yml
@@ -12,3 +12,7 @@ usage:
         - slack/approval-notification:
             message: "Pending approval"
             webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
+            channel: "CHANNELID" # Optional: Enter a channel id to override webhook's default channel
+            username: "username" # Optional: Enter an username to override webhook's default name
+            icon_emoji: ":smile:" # Optional: Enter an emoji code to override webhook's default icon
+            icon_url: "icon_url" # Optional: Enter an icon image URL to override webhook's default icon

--- a/src/examples/notify.yml
+++ b/src/examples/notify.yml
@@ -17,6 +17,9 @@ usage:
             color: "#42e2f4" # Optional: Assign custom colors for each notification
             webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
             channel: "CHANNELID" # Optional: Enter a channel id to override webhook's default channel
+            username: "username" # Optional: Enter an username to override webhook's default name
+            icon_emoji: ":smile:" # Optional: Enter an emoji code to override webhook's default icon
+            icon_url: "icon_url" # Optional: Enter an icon image URL to override webhook's default icon
 
   workflows:
     your-workflow:

--- a/src/examples/status.yml
+++ b/src/examples/status.yml
@@ -19,3 +19,7 @@ usage:
             fail_only: true # Optional: if set to `true` then only failure messages will occur.
             webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
             only_for_branches: "only_for_branches" # Optional: If set, a comma-separated list of branches (or a single branch) for which status updates will be sent.
+            channel: "CHANNELID" # Optional: Enter a channel id to override webhook's default channel
+            username: "username" # Optional: Enter an username to override webhook's default name
+            icon_emoji: ":smile:" # Optional: Enter an emoji code to override webhook's default icon
+            icon_url: "icon_url" # Optional: Enter an icon image URL to override webhook's default icon


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

refs #100 

In addition to `channel` parameter supported in #67, `username`, `icon_emoji` and `icon_url` parameters are available.
https://api.slack.com/custom-integrations/incoming-webhooks