### PR TITLE
feat: Allow suppressing certain fields for approvals

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,36 @@ jobs:
 
 ## Commands
 
+### Approval
+Send a notification that a manual approval job is ready
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `color` | `string` | '#3AA3E3' | Hex color value for notification attachment color. |
+| `mentions` | `string` | '' | A comma separated list of user IDs. No spaces. |
+| `message` | `string` | A workflow in CircleCI is awaiting your approval. | Enter custom message. |
+| `url` | `string` | 'https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}' | The URL to link back to. |
+| `webhook` | `string` | '${SLACK_WEBHOOK}' | Enter either your Webhook value or use the CircleCI UI to add your token under the 'SLACK_WEBHOOK' env var |
+
+Example:
+
+```yaml
+version: 2.1
+
+orbs:
+  slack: circleci/slack@x.y.z
+
+jobs:
+    docker:
+      - image: <docker image>
+    steps:
+      - slack/approval:
+          message: "This is a custom approval message" # Optional: Enter your own message
+          mentions: "USERID1,USERID2," # Optional: Enter the Slack IDs of any user or group (sub_team) to be mentioned
+          color: "#42e2f4" # Optional: Assign custom colors for each approval message
+          webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
+```
+
 ### Notify
 Notify a slack channel with a custom message at any point in a job with this custom step.
 
@@ -112,6 +142,25 @@ jobs:
 
 ![Status Success Example](/img/statusSuccess.PNG)
 ![Status Fail Example](/img/statusFail.PNG)
+
+## Jobs
+
+### approval-notification
+Send an approval notification message
+
+Example:
+
+```yaml
+version: 2.1
+
+orbs:
+  slack: circleci/slack@x.y.z
+
+jobs:
+  - slack/approval-notification:
+      color: "#aa7fcd" # Optional: Enter your own message
+      message: "Deployment pending approval" # Optional: Custom approval message
+```
 
 ## Dependencies / Requirements
 

--- a/src/commands/approval.yml
+++ b/src/commands/approval.yml
@@ -21,6 +21,18 @@ parameters:
     type: string
     default: ""
 
+  include_project_field:
+    type: boolean
+    default: true
+    description: >
+      Whether or not to include the Project field in the message
+
+  include_job_number_field:
+    type: boolean
+    default: true
+    description: >
+      Whether or not to include the Job Number field in the message
+
   url:
     description: The URL to link back to.
     type: string
@@ -76,16 +88,20 @@ steps:
                   \"fallback\": \"<< parameters.message >> - << parameters.url >>\", \
                   \"text\": \"<< parameters.message >> $SLACK_MENTIONS\", \
                   \"fields\": [ \
+                    <<# parameters.include_project_field >>
                     { \
                       \"title\": \"Project\", \
                       \"value\": \"$CIRCLE_PROJECT_REPONAME\", \
                       \"short\": true \
                     }, \
+                    <</ parameters.include_project_field >>
+                    <<# parameters.include_job_number_field >>
                     { \
                       \"title\": \"Job Number\", \
                       \"value\": \"$CIRCLE_BUILD_NUM\", \
                       \"short\": true \
                     } \
+                    <</ parameters.include_job_number_field >>
                   ], \
                   \"actions\": [ \
                     { \

--- a/src/jobs/approval-notification.yml
+++ b/src/jobs/approval-notification.yml
@@ -21,6 +21,18 @@ parameters:
     type: string
     default: ""
 
+  include_project_field:
+    type: boolean
+    default: true
+    description: >
+      Whether or not to include the Project field in the message
+
+  include_job_number_field:
+    type: boolean
+    default: true
+    description: >
+      Whether or not to include the Job Number field in the message
+
   url:
     description: The URL to link back to.
     type: string
@@ -34,4 +46,6 @@ steps:
       message: << parameters.message >>
       color: << parameters.color >>
       mentions: << parameters.mentions >>
+      include_project_field: << parameters.include_project_field >>
+      include_job_number_field: << parameters.include_job_number_field >>
       url: << parameters.url >>


### PR DESCRIPTION
### Checklist
- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
This addresses an inconsistency, where the project and job number fields can't be suppressed when sending an approval message, as they can in other contexts.

Let me know if there's a way to auto-generate the `README` (there should be if there isn't!), or if you want me to squash to one commit. Since the docs were missing entirely, I made two separate commits.

### Description
* Support suppressing `include_project_field` and `include_job_number_field` for the `approval` command and `approval-notification` job, similar to what's supported for other commands
* Add missing docs for the above types, including information about the new parameters