### PR TITLE
channel parameter is described concisely.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Notify a slack channel with a custom message at any point in a job with this cus
 | `include_project_field` | `boolean` | `true` | Condition to check if it is necessary to include the _Project_ field in the message |
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
 | `include_visit_job_action` | `boolean` | `true` | Whether or not to include the _Visit Job_ action in the message |
-| `channel` | `string` | | If set, overriding webhook's channel setting |
+| `channel` | `string` | | Name of concerned channel if set, overriding webhook's channel setting |
 
 [Slack message attachment]: https://api.slack.com/docs/message-attachments
 
@@ -85,7 +85,7 @@ Send a status alert at the end of a job based on success or failure. This must b
 | `include_project_field` | `boolean` | `true` | Whether or not to include the _Project_ field in the message |
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
 | `include_visit_job_action` | `boolean` | `true` | Whether or not to include the _Visit Job_ action in the message |
-| `channel` | `string` | | If set, overriding webhook's channel setting |
+| `channel` | `string` | | Name of concerned channel if set, overriding webhook's channel setting |
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Notify a slack channel with a custom message at any point in a job with this cus
 | `include_project_field` | `boolean` | `true` | Condition to check if it is necessary to include the _Project_ field in the message |
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
 | `include_visit_job_action` | `boolean` | `true` | Whether or not to include the _Visit Job_ action in the message |
-| `channel` | `string` | | ID of concerned channel if set, overriding webhook's channel setting |
+| `channel` | `string` | | ID of channel if set, overrides webhook's default channel setting |
 
 [Slack message attachment]: https://api.slack.com/docs/message-attachments
 
@@ -85,7 +85,7 @@ Send a status alert at the end of a job based on success or failure. This must b
 | `include_project_field` | `boolean` | `true` | Whether or not to include the _Project_ field in the message |
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
 | `include_visit_job_action` | `boolean` | `true` | Whether or not to include the _Visit Job_ action in the message |
-| `channel` | `string` | | ID of concerned channel if set, overriding webhook's channel setting |
+| `channel` | `string` | | ID of channel if set, overrides webhook's default channel setting |
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Notify a slack channel with a custom message at any point in a job with this cus
 | `include_project_field` | `boolean` | `true` | Condition to check if it is necessary to include the _Project_ field in the message |
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
 | `include_visit_job_action` | `boolean` | `true` | Whether or not to include the _Visit Job_ action in the message |
-| `channel` | `string` | | Name of concerned channel if set, overriding webhook's channel setting |
+| `channel` | `string` | | ID of concerned channel if set, overriding webhook's channel setting |
 
 [Slack message attachment]: https://api.slack.com/docs/message-attachments
 
@@ -85,7 +85,7 @@ Send a status alert at the end of a job based on success or failure. This must b
 | `include_project_field` | `boolean` | `true` | Whether or not to include the _Project_ field in the message |
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
 | `include_visit_job_action` | `boolean` | `true` | Whether or not to include the _Visit Job_ action in the message |
-| `channel` | `string` | | Name of concerned channel if set, overriding webhook's channel setting |
+| `channel` | `string` | | ID of concerned channel if set, overriding webhook's channel setting |
 
 Example:
 

--- a/src/commands/approval.yml
+++ b/src/commands/approval.yml
@@ -30,7 +30,7 @@ parameters:
     type: string
     default: ""
     description: >
-      Name of concerned channel if set, overriding webhook's channel setting
+      ID of channel if set, overrides webhook's default channel setting
 
 steps:
   - run:

--- a/src/commands/approval.yml
+++ b/src/commands/approval.yml
@@ -30,7 +30,7 @@ parameters:
     type: string
     default: ""
     description: >
-      If set, overriding webhook's channel setting
+      Name of concerned channel if set, overriding webhook's channel setting
 
 steps:
   - run:

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -70,7 +70,7 @@ parameters:
     type: string
     default: ""
     description: >
-      If set, overriding webhook's channel setting
+      Name of concerned channel if set, overriding webhook's channel setting
 
 steps:
   - run:

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -70,7 +70,7 @@ parameters:
     type: string
     default: ""
     description: >
-      Name of concerned channel if set, overriding webhook's channel setting
+      ID of channel if set, overrides webhook's default channel setting
 
 steps:
   - run:

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -61,7 +61,7 @@ parameters:
     type: string
     default: ""
     description: >
-      Name of concerned channel if set, overriding webhook's channel setting
+      ID of concerned channel if set, overriding webhook's channel setting
 
 steps:
   - run:

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -61,7 +61,7 @@ parameters:
     type: string
     default: ""
     description: >
-      If set, overriding webhook's channel setting
+      Name of concerned channel if set, overriding webhook's channel setting
 
 steps:
   - run:

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -61,7 +61,7 @@ parameters:
     type: string
     default: ""
     description: >
-      ID of concerned channel if set, overriding webhook's channel setting
+      ID of channel if set, overrides webhook's default channel setting
 
 steps:
   - run:


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ✓] All new jobs, commands, executors, parameters have descriptions
- [ ✓] Examples have been added for any significant new features
- [ ✓] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
#105 
### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
According to my understanding, after exploring this repo & slack api, channel parameter must be described as **channel ID** for avoiding any user misunderstanding of inputs & resulting any unnecessary errors. So, i have updated channel parameter description as channel ID in all jobs, commands, examples etc.
