### PR TITLE
Change resource_class to medium

### DIFF
--- a/src/executors/alpine.yml
+++ b/src/executors/alpine.yml
@@ -1,4 +1,4 @@
-resource_class: small
+resource_class: medium
 docker:
   - image: cibuilds/base:latest
     environment:


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ x ] All new jobs, commands, executors, parameters have descriptions
- [ x ] Examples have been added for any significant new features
- [ x ] README has been updated, if necessary

### Motivation, issues

Some users on CircleCI are unable to build using resource_class: small

### Description

Updated `resource_class: small` to `resource_class: medium`
