### PR TITLE
feat: Add channel param to approval-notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ jobs:
   - slack/approval-notification:
       color: "#aa7fcd" # Optional: Enter your own message
       message: "Deployment pending approval" # Optional: Custom approval message
+      channel: "CHANNELID" # Optional: If set, overrides webhook's default channel setting
 ```
 
 ## Dependencies / Requirements

--- a/src/jobs/approval-notification.yml
+++ b/src/jobs/approval-notification.yml
@@ -38,6 +38,12 @@ parameters:
     type: string
     default: https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}
 
+  channel:
+    type: string
+    default: ""
+    description: >
+      ID of channel if set, overrides webhook's default channel setting
+
 executor: alpine
 
 steps:
@@ -49,3 +55,4 @@ steps:
       include_project_field: << parameters.include_project_field >>
       include_job_number_field: << parameters.include_job_number_field >>
       url: << parameters.url >>
+      channel: << parameters.channel >>


### PR DESCRIPTION
### Checklist
- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
This just gives parity with the feature added in #67 to support overriding the channel for the approval command (and other commands)

### Description
* Add the ability to set the channel override in the approval-notification job and pass it through to the approval command (where the channel override was added in #67)