### PR TITLE
add `change_only` flag to status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Send a status alert at the end of a job based on success or failure. This must b
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
 | `include_visit_job_action` | `boolean` | `true` | Whether or not to include the _Visit Job_ action in the message |
 | `channel` | `string` | | ID of channel if set, overrides webhook's default channel setting |
+| `circle_token_name` | `string` | `CIRCLE_TOKEN` | The name of environment variable containing CircleCI API Token. Only required for private projects when `change_only` is set to true. |
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Send a status alert at the end of a job based on success or failure. This must b
 | `failure_message` | `string` | :red_circle: A $CIRCLE_JOB job has failed! $SLACK_MENTIONS | Enter your custom message to send to your Slack channel |
 | `mentions` | `string` |  | Comma-separated list of Slack User or Group (SubTeam) IDs (e.g., "USER1,USER2,USER3"). _**Note:** these are Slack User IDs, not usernames. The user ID can be found on the user's profile. Look below for information on obtaining Group ID._ |
 | `fail_only` | `boolean` | `false` | If set to `true`, successful jobs will _not_ send alerts |
+| `change_only` | `boolean` | `false` | If set to `true`, consecutive successes or failures will _not_ send alerts |
 | `only_for_branches` | `string` |  | If set, a comma-separated list of branches, for which to send notifications |
 | `include_project_field` | `boolean` | `true` | Whether or not to include the _Project_ field in the message |
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
@@ -136,6 +137,7 @@ jobs:
       - slack/status:
           mentions: "USERID1,USERID2" # Optional: Enter the Slack IDs of any user or group (sub_team) to be mentioned
           fail_only: true # Optional: if set to `true` then only failure messages will occur.
+          change_only: true # Optional: if set to `true` then only "change" in status messages will occur.
           webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
           only_for_branches: "master" # Optional: If set, a specific branch for which status updates will be sent. In this case, only for pushes to master branch.
 ```

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Send a status alert at the end of a job based on success or failure. This must b
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
 | `include_visit_job_action` | `boolean` | `true` | Whether or not to include the _Visit Job_ action in the message |
 | `channel` | `string` | | ID of channel if set, overrides webhook's default channel setting |
-| `circle_token_name` | `string` | `CIRCLE_TOKEN` | The name of environment variable containing CircleCI API Token. Only required for private projects when `change_only` is set to true. |
+| `circle_token_name` | `env_var_name` | `CIRCLE_TOKEN` | The name of environment variable containing CircleCI API Token. Only required for private projects when `change_only` is set to true. |
 
 Example:
 

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -26,6 +26,12 @@ parameters:
     description: >
       If `true`, notifications successful jobs will not be sent
 
+  change_only:
+    type: boolean
+    default: false
+    description: >
+      If `true`, notifications that are not "broke" or "fixed" will not be sent.
+
   mentions:
     type: string
     default: ""
@@ -125,6 +131,9 @@ steps:
               if [ << parameters.fail_only >> = true ]; then
                 echo "The job completed successfully"
                 echo '"fail_only" is set to "true". No Slack notification sent.'
+              elif [ << parameters.change_only >> = true ] && [ "fixed" != "$CIRCLE_JOB_STATUS_CHANGE" ]; then
+                echo "Job completed successfully."
+                echo '"change_only" is set to "true", and not "fixed". No Slack notification sent.'
               else
                 curl -X POST -H 'Content-type: application/json' \
                   --data "{ \
@@ -167,46 +176,51 @@ steps:
                 echo "Job completed successfully. Alert sent."
               fi
             else
-              #If Failed
-              curl -X POST -H 'Content-type: application/json' \
-                --data "{ \
-                  <<# parameters.channel >>
-                  \"channel\": \"<< parameters.channel >>\", \
-                  <</ parameters.channel >>
-                  \"attachments\": [ \
-                    { \
-                      \"fallback\": \"<< parameters.failure_message >>\", \
-                      \"text\": \"<< parameters.failure_message >> $SLACK_MENTIONS\", \
-                      \"fields\": [ \
-                        <<# parameters.include_project_field >>
-                        { \
-                          \"title\": \"Project\", \
-                          \"value\": \"$CIRCLE_PROJECT_REPONAME\", \
-                          \"short\": true \
-                        }, \
-                        <</ parameters.include_project_field >>
-                        <<# parameters.include_job_number_field >>
-                        { \
-                          \"title\": \"Job Number\", \
-                          \"value\": \"$CIRCLE_BUILD_NUM\", \
-                          \"short\": true \
-                        } \
-                        <</ parameters.include_job_number_field >>
-                      ], \
-                      \"actions\": [ \
-                        <<# parameters.include_visit_job_action >>
-                        { \
-                          \"type\": \"button\", \
-                          \"text\": \"Visit Job\", \
-                          \"url\": \"$CIRCLE_BUILD_URL\" \
-                        } \
-                        <</ parameters.include_visit_job_action >>
-                      ], \
-                      \"color\": \"#ed5c5c\" \
-                    } \
-                  ] \
-                } " << parameters.webhook >>
-              echo "Job failed. Alert sent."
+              if [ << parameters.change_only >> = true ] && [ "broke" != "$CIRCLE_JOB_STATUS_CHANGE" ]; then
+                echo "Job failed."
+                echo '"change_only" is set to "true", and not "broke". No Slack notification sent.'
+              else
+                #If Failed
+                curl -X POST -H 'Content-type: application/json' \
+                  --data "{ \
+                    <<# parameters.channel >>
+                    \"channel\": \"<< parameters.channel >>\", \
+                    <</ parameters.channel >>
+                    \"attachments\": [ \
+                      { \
+                        \"fallback\": \"<< parameters.failure_message >>\", \
+                        \"text\": \"<< parameters.failure_message >> $SLACK_MENTIONS\", \
+                        \"fields\": [ \
+                          <<# parameters.include_project_field >>
+                          { \
+                            \"title\": \"Project\", \
+                            \"value\": \"$CIRCLE_PROJECT_REPONAME\", \
+                            \"short\": true \
+                          }, \
+                          <</ parameters.include_project_field >>
+                          <<# parameters.include_job_number_field >>
+                          { \
+                            \"title\": \"Job Number\", \
+                            \"value\": \"$CIRCLE_BUILD_NUM\", \
+                            \"short\": true \
+                          } \
+                          <</ parameters.include_job_number_field >>
+                        ], \
+                        \"actions\": [ \
+                          <<# parameters.include_visit_job_action >>
+                          { \
+                            \"type\": \"button\", \
+                            \"text\": \"Visit Job\", \
+                            \"url\": \"$CIRCLE_BUILD_URL\" \
+                          } \
+                          <</ parameters.include_visit_job_action >>
+                        ], \
+                        \"color\": \"#ed5c5c\" \
+                      } \
+                    ] \
+                  } " << parameters.webhook >>
+                echo "Job failed. Alert sent."
+              fi
             fi
           fi
         else

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -69,6 +69,12 @@ parameters:
     description: >
       ID of channel if set, overrides webhook's default channel setting
 
+  circle_token_name:
+    default: CIRCLE_TOKEN
+    description: The name of environment variable containing CircleCI API Token.
+      Only required for private projects.
+    type: string
+
 steps:
   - run:
       name: Slack - Setting Failure Condition
@@ -89,6 +95,31 @@ steps:
           echo Bash not installed.
           exit 1
         fi
+
+  - run:
+      name: Slack - Setting previous build status if needed
+      shell: /bin/bash
+      when: always
+      command: |
+        <<# parameters.change_only >>
+        set -e
+
+        # Support both https://github.com/user/project and git@github.com:user/project.git
+        if [[ $(echo $CIRCLE_REPOSITORY_URL | sed -e 's|^[^/]*//||' -e 's|/.*$||' -e 's|^[^@]*@||' -e 's|:.*$||' | grep github.com) ]]; then
+          VCS_TYPE=github
+        else
+          VCS_TYPE=bitbucket
+        fi
+
+        LAST_BUILD_STATUS=$(\
+            curl -Lfs <<# parameters.circle_token_name >> --user "${<<parameters.circle_token_name>>}:" <</parameters.circle_token_name>> \
+            https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_PREVIOUS_BUILD_NUM} \
+            | jq -r .outcome \
+        )
+
+        echo "export SLACK_LAST_BUILD_STATUS=$LAST_BUILD_STATUS" >> $BASH_ENV
+        <</ parameters.change_only >>
+        exit 0
 
   - run:
       name: Slack - Sending Status Alert
@@ -131,7 +162,7 @@ steps:
               if [ << parameters.fail_only >> = true ]; then
                 echo "The job completed successfully"
                 echo '"fail_only" is set to "true". No Slack notification sent.'
-              elif [ << parameters.change_only >> = true ] && [ "fixed" != "$CIRCLE_JOB_STATUS_CHANGE" ]; then
+              elif [ << parameters.change_only >> = true ] && [ "success" = "$SLACK_LAST_BUILD_STATUS" ]; then
                 echo "Job completed successfully."
                 echo '"change_only" is set to "true", and not "fixed". No Slack notification sent.'
               else
@@ -176,7 +207,7 @@ steps:
                 echo "Job completed successfully. Alert sent."
               fi
             else
-              if [ << parameters.change_only >> = true ] && [ "broke" != "$CIRCLE_JOB_STATUS_CHANGE" ]; then
+              if [ << parameters.change_only >> = true ] && [ "success" != "$SLACK_LAST_BUILD_STATUS" ]; then
                 echo "Job failed."
                 echo '"change_only" is set to "true", and not "broke". No Slack notification sent.'
               else

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -72,7 +72,7 @@ parameters:
   circle_token_name:
     default: CIRCLE_TOKEN
     description: The name of environment variable containing CircleCI API Token.
-      Only required for private projects.
+      Only required for private projects when `change_only` is set to true.
     type: string
 
 steps:

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -30,7 +30,7 @@ parameters:
     type: boolean
     default: false
     description: >
-      If `true`, notifications that are not "broke" or "fixed" will not be sent.
+      If `true`, notifications that are not newly "failed" or "fixed" will not be sent.
 
   mentions:
     type: string
@@ -73,7 +73,7 @@ parameters:
     default: CIRCLE_TOKEN
     description: The name of environment variable containing CircleCI API Token.
       Only required for private projects when `change_only` is set to true.
-    type: string
+    type: env_var_name
 
 steps:
   - run:
@@ -207,9 +207,9 @@ steps:
                 echo "Job completed successfully. Alert sent."
               fi
             else
-              if [ << parameters.change_only >> = true ] && [ "success" != "$SLACK_LAST_BUILD_STATUS" ]; then
+              if [ << parameters.change_only >> = true ] && [ "" = "$SLACK_LAST_BUILD_STATUS" ]; then
                 echo "Job failed."
-                echo '"change_only" is set to "true", and not "broke". No Slack notification sent.'
+                echo '"change_only" is set to "true", and not newly "failed". No Slack notification sent.'
               else
                 #If Failed
                 curl -X POST -H 'Content-type: application/json' \

--- a/src/examples/status.yml
+++ b/src/examples/status.yml
@@ -17,5 +17,6 @@ usage:
         - slack/status:
             mentions: "USERID1,USERID2" # Optional: Enter the Slack IDs of any user or group (sub_team) to be mentioned
             fail_only: true # Optional: if set to `true` then only failure messages will occur.
+            change_only: true # Optional: If set to `true` then only messages for changes in status will occur.
             webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
             only_for_branches: "only_for_branches" # Optional: If set, a comma-separated list of branches (or a single branch) for which status updates will be sent.


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Closes #54 

In some cases, users will want to only be notified of status **changes** instead of all Ci statuses.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Add `change_only` flag to command `status`.

When disabled, it has no impact.

When enabled, the status is reported to slack only on `fixed` or `broke` statuses.
For example, with the following statuses over time:

Status | Experience
------|------------
Pass | No Alert
Pass | No Alert
Pass | No Alert
Fail | Send Alert
Fail | No Alert
Fail | No Alert
Fail | No Alert
Pass | Send Alert
Fail | Send Alert
Fail | No Alert
Pass | Send Alert
Pass | No Alert
Pass | No Alert
Pass | No Alert

