### PR TITLE
add `when` flag to status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ Send a status alert at the end of a job based on success or failure. This must b
 | `success_message` | `string` | :tada: A $CIRCLE_JOB job has succeeded! $SLACK_MENTIONS | Enter your custom message to send to your Slack channel |
 | `failure_message` | `string` | :red_circle: A $CIRCLE_JOB job has failed! $SLACK_MENTIONS | Enter your custom message to send to your Slack channel |
 | `mentions` | `string` |  | Comma-separated list of Slack User or Group (SubTeam) IDs (e.g., "USER1,USER2,USER3"). _**Note:** these are Slack User IDs, not usernames. The user ID can be found on the user's profile. Look below for information on obtaining Group ID._ |
-| `success_only` | `boolean` | `false` | If set to `true`, failed jobs will _not_ send alerts |
-| `fail_only` | `boolean` | `false` | If set to `true`, successful jobs will _not_ send alerts |
+| `when` | `enum` | `always` | When to send alerts - `always` to always send an alert, `on_success` to only send for successful jobs, and `on_failure` to only send on failed jobs. |
+| `fail_only` | `boolean` | `false` | If set to `true`, successful jobs will _not_ send alerts. *Deprecated*: use the `when: on_fail` parameter.  |
 | `only_for_branches` | `string` |  | If set, a comma-separated list of branches, for which to send notifications |
 | `include_project_field` | `boolean` | `true` | Whether or not to include the _Project_ field in the message |
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Send a status alert at the end of a job based on success or failure. This must b
 | `success_message` | `string` | :tada: A $CIRCLE_JOB job has succeeded! $SLACK_MENTIONS | Enter your custom message to send to your Slack channel |
 | `failure_message` | `string` | :red_circle: A $CIRCLE_JOB job has failed! $SLACK_MENTIONS | Enter your custom message to send to your Slack channel |
 | `mentions` | `string` |  | Comma-separated list of Slack User or Group (SubTeam) IDs (e.g., "USER1,USER2,USER3"). _**Note:** these are Slack User IDs, not usernames. The user ID can be found on the user's profile. Look below for information on obtaining Group ID._ |
+| `success_only` | `boolean` | `false` | If set to `true`, failed jobs will _not_ send alerts |
 | `fail_only` | `boolean` | `false` | If set to `true`, successful jobs will _not_ send alerts |
 | `only_for_branches` | `string` |  | If set, a comma-separated list of branches, for which to send notifications |
 | `include_project_field` | `boolean` | `true` | Whether or not to include the _Project_ field in the message |

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -35,7 +35,7 @@ parameters:
     default: false
     description: >
       If `true`, notifications successful jobs will not be sent
-      *Deprecated*: use the `when` parameters
+      *Deprecated*: use the `when: on_fail` parameter.
 
   mentions:
     type: string

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -35,6 +35,7 @@ parameters:
     default: false
     description: >
       If `true`, notifications successful jobs will not be sent
+      *Deprecated*: use the `when` parameters
 
   mentions:
     type: string

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -20,6 +20,12 @@ parameters:
     default: ":red_circle: A $CIRCLE_JOB job has failed!"
     description: Enter custom message.
 
+  success_only:
+    type: boolean
+    default: false
+    description: >
+      If `true`, notifications of failed jobs will not be sent
+
   fail_only:
     type: boolean
     default: false
@@ -168,45 +174,51 @@ steps:
               fi
             else
               #If Failed
-              curl -X POST -H 'Content-type: application/json' \
-                --data "{ \
-                  <<# parameters.channel >>
-                  \"channel\": \"<< parameters.channel >>\", \
-                  <</ parameters.channel >>
-                  \"attachments\": [ \
-                    { \
-                      \"fallback\": \"<< parameters.failure_message >>\", \
-                      \"text\": \"<< parameters.failure_message >> $SLACK_MENTIONS\", \
-                      \"fields\": [ \
-                        <<# parameters.include_project_field >>
-                        { \
-                          \"title\": \"Project\", \
-                          \"value\": \"$CIRCLE_PROJECT_REPONAME\", \
-                          \"short\": true \
-                        }, \
-                        <</ parameters.include_project_field >>
-                        <<# parameters.include_job_number_field >>
-                        { \
-                          \"title\": \"Job Number\", \
-                          \"value\": \"$CIRCLE_BUILD_NUM\", \
-                          \"short\": true \
-                        } \
-                        <</ parameters.include_job_number_field >>
-                      ], \
-                      \"actions\": [ \
-                        <<# parameters.include_visit_job_action >>
-                        { \
-                          \"type\": \"button\", \
-                          \"text\": \"Visit Job\", \
-                          \"url\": \"$CIRCLE_BUILD_URL\" \
-                        } \
-                        <</ parameters.include_visit_job_action >>
-                      ], \
-                      \"color\": \"#ed5c5c\" \
-                    } \
-                  ] \
-                } " << parameters.webhook >>
-              echo "Job failed. Alert sent."
+              #Skip if fail_only
+              if [ << parameters.success_only >> = true ]; then
+                echo "Job failed."
+                echo '"success_only" is set to "true". No Slack notification sent.'
+              else
+                curl -X POST -H 'Content-type: application/json' \
+                  --data "{ \
+                    <<# parameters.channel >>
+                    \"channel\": \"<< parameters.channel >>\", \
+                    <</ parameters.channel >>
+                    \"attachments\": [ \
+                      { \
+                        \"fallback\": \"<< parameters.failure_message >>\", \
+                        \"text\": \"<< parameters.failure_message >> $SLACK_MENTIONS\", \
+                        \"fields\": [ \
+                          <<# parameters.include_project_field >>
+                          { \
+                            \"title\": \"Project\", \
+                            \"value\": \"$CIRCLE_PROJECT_REPONAME\", \
+                            \"short\": true \
+                          }, \
+                          <</ parameters.include_project_field >>
+                          <<# parameters.include_job_number_field >>
+                          { \
+                            \"title\": \"Job Number\", \
+                            \"value\": \"$CIRCLE_BUILD_NUM\", \
+                            \"short\": true \
+                          } \
+                          <</ parameters.include_job_number_field >>
+                        ], \
+                        \"actions\": [ \
+                          <<# parameters.include_visit_job_action >>
+                          { \
+                            \"type\": \"button\", \
+                            \"text\": \"Visit Job\", \
+                            \"url\": \"$CIRCLE_BUILD_URL\" \
+                          } \
+                          <</ parameters.include_visit_job_action >>
+                        ], \
+                        \"color\": \"#ed5c5c\" \
+                      } \
+                    ] \
+                  } " << parameters.webhook >>
+                echo "Job failed. Alert sent."
+              fi
             fi
           fi
         else

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -20,9 +20,13 @@ parameters:
     default: ":red_circle: A $CIRCLE_JOB job has failed!"
     description: Enter custom message.
 
-  success_only:
-    type: boolean
-    default: false
+  when:
+    type: enum
+    enum:
+      - always
+      - on_fail
+      - on_success
+    default: always
     description: >
       If `true`, notifications of failed jobs will not be sent
 
@@ -105,6 +109,12 @@ steps:
           fi
         done
 
+        SLACK_NOTIFY_WHEN="<< parameters.when >>"
+
+        if [ << parameters.fail_only >> = true ]; then
+          SLACK_NOTIFY_WHEN="on_fail"
+        fi
+
         if [ "x" == "x<< parameters.only_for_branches>>" ] || [ "$current_branch_in_filter" = true ]; then
           # Provide error if no webhook is set and error. Otherwise continue
           if [ -z "<< parameters.webhook >>" ]; then
@@ -128,9 +138,9 @@ steps:
             #If successful
             if [ "$SLACK_BUILD_STATUS" = "success" ]; then
               #Skip if fail_only
-              if [ << parameters.fail_only >> = true ]; then
+              if [ "$SLACK_NOTIFY_WHEN" == "on_fail" ]; then
                 echo "The job completed successfully"
-                echo '"fail_only" is set to "true". No Slack notification sent.'
+                echo '`when` is set to "on_fail". No Slack notification sent.'
               else
                 curl -X POST -H 'Content-type: application/json' \
                   --data "{ \
@@ -175,9 +185,9 @@ steps:
             else
               #If Failed
               #Skip if fail_only
-              if [ << parameters.success_only >> = true ]; then
+              if [ "$SLACK_NOTIFY_WHEN" == "on_success" ]; then
                 echo "Job failed."
-                echo '"success_only" is set to "true". No Slack notification sent.'
+                echo '`when` is set to "on_success". No Slack notification sent.'
               else
                 curl -X POST -H 'Content-type: application/json' \
                   --data "{ \

--- a/src/examples/status.yml
+++ b/src/examples/status.yml
@@ -16,6 +16,6 @@ usage:
 
         - slack/status:
             mentions: "USERID1,USERID2" # Optional: Enter the Slack IDs of any user or group (sub_team) to be mentioned
-            fail_only: true # Optional: if set to `true` then only failure messages will occur.
+            when: on_fail # Optional: if set to `on_fail` then only failure messages will occur.
             webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
             only_for_branches: "only_for_branches" # Optional: If set, a comma-separated list of branches (or a single branch) for which status updates will be sent.


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

This ( along with #110 ) Closes #92

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Adds `when` flag to the `status` command.  This enum flag works like all other `circleci` `when` flags by limiting the notification to only send `on_success`/`on_fail`