### PR TITLE
Change Copyright to Circle Internet Services, Inc.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 CircleCI Public
+Copyright (c) 2019 Circle Internet Services, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

The copyright information included in the `LICENSE` file is incorrect and should be "Circle Internet Services, Inc." compared to the other Orb repos.