### PR TITLE
Support sending notifications on tags (#124)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Send a status alert at the end of a job based on success or failure. This must b
 | `mentions` | `string` |  | Comma-separated list of Slack User or Group (SubTeam) IDs (e.g., "USER1,USER2,USER3"). _**Note:** these are Slack User IDs, not usernames. The user ID can be found on the user's profile. Look below for information on obtaining Group ID._ |
 | `fail_only` | `boolean` | `false` | If set to `true`, successful jobs will _not_ send alerts |
 | `only_for_branches` | `string` |  | If set, a comma-separated list of branches, for which to send notifications |
+| `use_on_tags` | `string` |  | Set to the same pattern as the workflow tag filter to notify on tags. Set to empty string to match all tags. |
 | `include_project_field` | `boolean` | `true` | Whether or not to include the _Project_ field in the message |
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
 | `include_visit_job_action` | `boolean` | `true` | Whether or not to include the _Visit Job_ action in the message |
@@ -138,6 +139,7 @@ jobs:
           fail_only: true # Optional: if set to `true` then only failure messages will occur.
           webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
           only_for_branches: "master" # Optional: If set, a specific branch for which status updates will be sent. In this case, only for pushes to master branch.
+          use_on_tags: "/^v.*/" # Optional: Set to the same regex as the workflow tag filter, or empty string to match all tags. In this case, all tags starting with "v"
 ```
 
 ![Status Success Example](/img/statusSuccess.PNG)

--- a/src/commands/notify-on-failure.yml
+++ b/src/commands/notify-on-failure.yml
@@ -10,7 +10,15 @@ parameters:
       If set, a comma-separated list of branches for which to send
       notifications. No spaces.
 
+  use_on_tags:
+    type: string
+    default: "match-nothing" # hopefully no one will use this as a tag (:
+    description: >
+      Set to the same pattern as the workflow tag filter to notify on tags.
+      Set to empty string to match all tags.
+
 steps:
   - status:
       fail_only: true
       only_for_branches: <<parameters.only_for_branches>>
+      use_on_tags: <<parameters.use_on_tags>>

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -39,6 +39,13 @@ parameters:
       If set, a comma-separated list of branches for which to send
       notifications. No spaces.
 
+  use_on_tags:
+    type: string
+    default: "match-nothing" # hopefully no one will use this as a tag (:
+    description: >
+      Set to the same pattern as the workflow tag filter to notify on tags.
+      Set to empty string to match all tags.
+
   include_project_field:
     type: boolean
     default: true
@@ -104,6 +111,11 @@ steps:
             current_branch_in_filter=true
           fi
         done
+
+        tag_regex="<< parameters.use_on_tags >>"
+        if [ -n "$CIRCLE_TAG" ] && echo $CIRCLE_TAG | grep -E "${tag_regex//\/}" 1>/dev/null; then
+          current_branch_in_filter=true
+        fi
 
         if [ "x" == "x<< parameters.only_for_branches>>" ] || [ "$current_branch_in_filter" = true ]; then
           # Provide error if no webhook is set and error. Otherwise continue

--- a/src/examples/status.yml
+++ b/src/examples/status.yml
@@ -19,3 +19,4 @@ usage:
             fail_only: true # Optional: if set to `true` then only failure messages will occur.
             webhook: "webhook" # Optional: Enter a specific webhook here or the default will use $SLACK_WEBHOOK
             only_for_branches: "only_for_branches" # Optional: If set, a comma-separated list of branches (or a single branch) for which status updates will be sent.
+            use_on_tags: "/^v.*/" # Optional: Set to the same regex as the workflow tag filter, or empty string to match all tags.


### PR DESCRIPTION
Fixes: #124

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

To send notifications on a tagged build, you would have to use a hack (see my comment in #124).

Apart from not having to rely on hack, this gives the user a more flexible solution instead of just an on/off-switch.

### Description

Add `use_on_tag` to `status` (and `notify-on-failure`) to enable users to push slack messages on tags with a greater level of granularity.
