### PR TITLE
Notify command: added new author_icon parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Notify a slack channel with a custom message at any point in a job with this cus
 | `color` | `string` | #333333 |  Hex color value for notification attachment color |
 | `author_name` | `string` |  | Optional author name property for the [Slack message attachment] |
 | `author_link` | `string` |  | Optional author link property for the [Slack message attachment] |
+| `author_icon` | `string` |  | Optional author icon property for the [Slack message attachment] |
 | `title` | `string` |  | Optional title property for the [Slack message attachment] |
 | `title_link` | `string` |  | Optional title link property for the [Slack message attachment] |
 | `footer` | `string` |  | Optional footer property for the [Slack message attachment] |

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -31,6 +31,11 @@ parameters:
     type: string
     default: ""
 
+  author_icon:
+    description: Optional author icon
+    type: string
+    default: ""
+
   title:
     description: Optional title
     type: string
@@ -124,6 +129,7 @@ steps:
                   \"text\": \"<< parameters.message >> $SLACK_MENTIONS\", \
                   \"author_name\": \"<< parameters.author_name >>\", \
                   \"author_link\": \"<< parameters.author_link >>\", \
+                  \"author_icon\": \"<< parameters.author_icon >>\", \
                   \"title\": \"<< parameters.title >>\", \
                   \"title_link\": \"<< parameters.title_link >>\", \
                   \"footer\": \"<< parameters.footer >>\", \


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
To be able to show an icon next to the notification user in slack :)
We currently cannot customize the icon for the "incoming-webhook"

### Description

<!---
added a parameter in notify.yml.
 -->
