### PR TITLE
Notify on failure for master only

### DIFF
--- a/src/commands/notify-on-failure.yml
+++ b/src/commands/notify-on-failure.yml
@@ -5,7 +5,7 @@ description: >
 parameters:
   only_for_branches:
     type: string
-    default: ""
+    default: "master"
     description: >
       If set, a comma-separated list of branches for which to send
       notifications. No spaces.


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

`slack/notify-on-failure` notifies on failure for every branch, while the documentation mentions it's supposed to only notify for failures on `master`. this might have been an accidental change in https://github.com/CircleCI-Public/slack-orb/commit/1bc9b0b8d5db1c615b5c016fd7b51f72389b9206#diff-2b8d8a04736b4ccc6b622ccf90f21e90R8

### Description

Re-added `master` as the default branch for `slack/notify-on-failure` (reverting to behavior in 3.4.1)