### PR TITLE
Add option to show branch in Slack message. Based on work from @Gabri…

### DIFF
--- a/src/commands/approval.yml
+++ b/src/commands/approval.yml
@@ -33,6 +33,12 @@ parameters:
     description: >
       Whether or not to include the Job Number field in the message
 
+  include_job_branch_field:
+    type: boolean
+    default: true
+    description: >
+      Whether or not to include the Job branch field in the message
+
   url:
     description: The URL to link back to.
     type: string
@@ -106,8 +112,15 @@ steps:
                       \"title\": \"Job Number\", \
                       \"value\": \"$CIRCLE_BUILD_NUM\", \
                       \"short\": true \
-                    } \
+                    }, \
                     <</ parameters.include_job_number_field >>
+                    <<# parameters.include_job_branch_field >>
+                    { \
+                      \"title\": \"Job Branch\", \
+                      \"value\": \"$CIRCLE_BRANCH\", \
+                      \"short\": true \
+                    } \
+                    <</ parameters.include_job_branch_field >>
                   ], \
                   \"actions\": [ \
                     { \

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -61,6 +61,11 @@ parameters:
     type: boolean
     default: true
 
+  include_job_branch_field:
+    description: Whether or not to include the Job branch field in the message
+    type: boolean
+    default: true
+
   include_job_number_field:
     description: Whether or not to include the Job Number field in the message
     type: boolean
@@ -147,8 +152,15 @@ steps:
                       \"title\": \"Job Number\", \
                       \"value\": \"$CIRCLE_BUILD_NUM\", \
                       \"short\": true \
-                    } \
+                    }, \
                     <</ parameters.include_job_number_field >>
+                    <<# parameters.include_job_branch_field >>
+                    { \
+                      \"title\": \"Job Branch\", \
+                      \"value\": \"$CIRCLE_BRANCH\", \
+                      \"short\": true \
+                    } \
+                    <</ parameters.include_job_branch_field >>
                   ], \
                   \"actions\": [ \
                     <<# parameters.include_visit_job_action >>

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -51,6 +51,12 @@ parameters:
     description: >
       Whether or not to include the Project field in the message
 
+  include_job_branch_field:
+    type: boolean
+    default: true
+    description: >
+      Whether or not to include the Job branch field in the message
+
   include_job_number_field:
     type: boolean
     default: true
@@ -160,8 +166,15 @@ steps:
                                     \"title\": \"Job Number\", \
                                     \"value\": \"$CIRCLE_BUILD_NUM\", \
                                     \"short\": true \
-                                  } \
+                                  }, \
                                   <</ parameters.include_job_number_field >>
+                                  <<# parameters.include_job_branch_field >>
+                                  { \
+                                    \"title\": \"Job Branch\", \
+                                    \"value\": \"$CIRCLE_BRANCH\", \
+                                    \"short\": true \
+                                  } \
+                                  <</ parameters.include_job_branch_field >>
                                 ], \
                                 \"actions\": [ \
                                   <<# parameters.include_visit_job_action >>
@@ -208,8 +221,15 @@ steps:
                             \"title\": \"Job Number\", \
                             \"value\": \"$CIRCLE_BUILD_NUM\", \
                             \"short\": true \
-                          } \
+                          }, \
                           <</ parameters.include_job_number_field >>
+                          <<# parameters.include_job_branch_field >>
+                          { \
+                            \"title\": \"Job Branch\", \
+                            \"value\": \"$CIRCLE_BRANCH\", \
+                            \"short\": true \
+                          } \
+                          <</ parameters.include_job_branch_field >>
                         ], \
                         \"actions\": [ \
                           <<# parameters.include_visit_job_action >>

--- a/src/jobs/approval-notification.yml
+++ b/src/jobs/approval-notification.yml
@@ -33,6 +33,12 @@ parameters:
     description: >
       Whether or not to include the Job Number field in the message
 
+  include_job_branch_field:
+    type: boolean
+    default: true
+    description: >
+      Whether or not to include the Job branch field in the message
+
   url:
     description: The URL to link back to.
     type: string
@@ -54,5 +60,6 @@ steps:
       mentions: << parameters.mentions >>
       include_project_field: << parameters.include_project_field >>
       include_job_number_field: << parameters.include_job_number_field >>
+      include_job_branch_field: << parameters.include_job_branch_field >>
       url: << parameters.url >>
       channel: << parameters.channel >>


### PR DESCRIPTION
### Checklist
* [x]  All new jobs, commands, executors, parameters have descriptions
* [ ]  Examples have been added for any significant new features
* [ ]  README has been updated, if necessary

### Motivation, issues
Show the branch in which the job has been failed or successful is helpful if you have the same jobs across different branch

### Description
Just add the **job_branch_field** as parameter and print it as part of the slack message in the curl command in the different **commands** files

