### PR TITLE
Fix commands so they work when using Windows executor with bash shell

### DIFF
--- a/src/commands/approval.yml
+++ b/src/commands/approval.yml
@@ -61,7 +61,7 @@ steps:
 
   - run:
       name: Slack - Sending Approval Notification
-      shell: /bin/bash
+      shell: bash
       command: |
         # Provide error if no webhook is set and error. Otherwise continue
         if [ -z "<< parameters.webhook >>" ]; then

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -94,7 +94,7 @@ steps:
 
   - run:
       name: Slack Notification
-      shell: /bin/bash
+      shell: bash
       command: |
         # Provide error if no webhook is set and error. Otherwise continue
         if [ -z "<< parameters.webhook >>" ]; then

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -98,7 +98,7 @@ steps:
 
   - run:
       name: Slack - Sending Status Alert
-      shell: /bin/bash
+      shell: bash
       when: always
       command: |
         current_branch_in_filter=false


### PR DESCRIPTION
I believe this change should fix an issue with commands inside this orb not working with Windows executor which utilizes bash shell.

## Background, Motivation

Right now commands from this orb fail with the following error when trying to use them inside a job which uses Windows executor:

```bash
failed to start cmd: exec: "/bin/bash": file does not exist
```

Here is an example - https://app.circleci.com/pipelines/github/scalyr/scalyr-agent-2/3007/workflows/f81f6698-e1fa-4ffe-ac8a-6035985ba39d/jobs/40917/parallel-runs/0/steps/0-111.

## Proposed Implementation / Fix

In my proposed fix I just specify ``bash`` for the ``shell`` attribute value.

I think that's better and more robust than specifying an absolute path and it's also more in line with ``#!/usr/bin/env bash`` notation which is usually also preferred over specifying a full absolute path in the shebang line in the shell scripts.

I tested it by moving the orb definition in-line and it works fine (it's faster that way compared to publishing a new dev version of an orb under my account):

* https://github.com/scalyr/scalyr-agent-2/pull/569/commits/a4c5175f2d59715f2e2a8856d2ed423a582c2711
* https://app.circleci.com/pipelines/github/scalyr/scalyr-agent-2/3034/workflows/ad40eea5-4a3a-43f1-b7e1-4f1ded286229/jobs/41364

I also verified that this approach works fine with OS X and Docker executor - https://github.com/scalyr/scalyr-agent-2/pull/569/commits/132c0a736a91bf636c4f195221d42a941d4002dd.