### PR TITLE
Add include_branch_field arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Send a notification that a manual approval job is ready
 | `color` | `string` | '#3AA3E3' | Hex color value for notification attachment color. |
 | `mentions` | `string` | '' | A comma separated list of user IDs. No spaces. |
 | `message` | `string` | A workflow in CircleCI is awaiting your approval. | Enter custom message. |
+| `include_branch_field` | `boolean` | `true` | Whether or not to include the _Branch_ field in the message |
 | `url` | `string` | 'https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}' | The URL to link back to. |
 | `webhook` | `string` | '${SLACK_WEBHOOK}' | Enter either your Webhook value or use the CircleCI UI to add the webhook under the 'SLACK_WEBHOOK' env var |
 
@@ -74,6 +75,7 @@ Notify a slack channel with a custom message at any point in a job with this cus
 | `include_project_field` | `boolean` | `true` | Condition to check if it is necessary to include the _Project_ field in the message |
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
 | `include_visit_job_action` | `boolean` | `true` | Whether or not to include the _Visit Job_ action in the message |
+| `include_branch_field` | `boolean` | `true` | Whether or not to include the _Branch_ field in the message |
 | `channel` | `string` | | ID of channel if set, overrides webhook's default channel setting |
 
 [Slack message attachment]: https://api.slack.com/docs/message-attachments
@@ -117,6 +119,7 @@ Send a status alert at the end of a job based on success or failure. This must b
 | `include_project_field` | `boolean` | `true` | Whether or not to include the _Project_ field in the message |
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
 | `include_visit_job_action` | `boolean` | `true` | Whether or not to include the _Visit Job_ action in the message |
+| `include_branch_field` | `boolean` | `true` | Whether or not to include the _Branch_ field in the message |
 | `channel` | `string` | | ID of channel if set, overrides webhook's default channel setting |
 
 Example:

--- a/src/commands/approval.yml
+++ b/src/commands/approval.yml
@@ -33,6 +33,12 @@ parameters:
     description: >
       Whether or not to include the Job Number field in the message
 
+  include_branch_field:
+    type: boolean
+    default: true
+    description: >
+      Whether or not to include the Branch field in the message
+
   url:
     description: The URL to link back to.
     type: string
@@ -106,8 +112,15 @@ steps:
                       \"title\": \"Job Number\", \
                       \"value\": \"$CIRCLE_BUILD_NUM\", \
                       \"short\": true \
-                    } \
+                    }, \
                     <</ parameters.include_job_number_field >>
+                    <<# parameters.include_branch_field >>
+                    { \
+                      \"title\": \"Branch\", \
+                      \"value\": \"$CIRCLE_BRANCH\", \
+                      \"short\": true \
+                    } \
+                    <</ parameters.include_branch_field >>
                   ], \
                   \"actions\": [ \
                     { \

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -71,6 +71,12 @@ parameters:
     type: boolean
     default: true
 
+  include_branch_field:
+    type: boolean
+    default: true
+    description: >
+      Whether or not to include the Branch field in the message
+
   channel:
     type: string
     default: ""
@@ -147,8 +153,15 @@ steps:
                       \"title\": \"Job Number\", \
                       \"value\": \"$CIRCLE_BUILD_NUM\", \
                       \"short\": true \
-                    } \
+                    }, \
                     <</ parameters.include_job_number_field >>
+                    <<# parameters.include_branch_field >>
+                    { \
+                      \"title\": \"Branch\", \
+                      \"value\": \"$CIRCLE_BRANCH\", \
+                      \"short\": true \
+                    } \
+                    <</ parameters.include_branch_field >>
                   ], \
                   \"actions\": [ \
                     <<# parameters.include_visit_job_action >>

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -63,6 +63,12 @@ parameters:
     description: >
       Whether or not to include the Visit Job action in the message
 
+  include_branch_field:
+    type: boolean
+    default: true
+    description: >
+      Whether or not to include the Branch field in the message
+
   channel:
     type: string
     default: ""
@@ -160,8 +166,15 @@ steps:
                                     \"title\": \"Job Number\", \
                                     \"value\": \"$CIRCLE_BUILD_NUM\", \
                                     \"short\": true \
-                                  } \
+                                  }, \
                                   <</ parameters.include_job_number_field >>
+                                  <<# parameters.include_branch_field >>
+                                  { \
+                                    \"title\": \"Branch\", \
+                                    \"value\": \"$CIRCLE_BRANCH\", \
+                                    \"short\": true \
+                                  } \
+                                  <</ parameters.include_branch_field >>
                                 ], \
                                 \"actions\": [ \
                                   <<# parameters.include_visit_job_action >>
@@ -208,8 +221,15 @@ steps:
                             \"title\": \"Job Number\", \
                             \"value\": \"$CIRCLE_BUILD_NUM\", \
                             \"short\": true \
-                          } \
+                          }, \
                           <</ parameters.include_job_number_field >>
+                          <<# parameters.include_branch_field >>
+                          { \
+                            \"title\": \"Branch\", \
+                            \"value\": \"$CIRCLE_BRANCH\", \
+                            \"short\": true \
+                          } \
+                          <</ parameters.include_branch_field >>
                         ], \
                         \"actions\": [ \
                           <<# parameters.include_visit_job_action >>

--- a/src/jobs/approval-notification.yml
+++ b/src/jobs/approval-notification.yml
@@ -33,6 +33,12 @@ parameters:
     description: >
       Whether or not to include the Job Number field in the message
 
+  include_branch_field:
+    type: boolean
+    default: true
+    description: >
+      Whether or not to include the Branch field in the message
+
   url:
     description: The URL to link back to.
     type: string
@@ -54,5 +60,6 @@ steps:
       mentions: << parameters.mentions >>
       include_project_field: << parameters.include_project_field >>
       include_job_number_field: << parameters.include_job_number_field >>
+      include_branch_field: << parameters.include_branch_field >>
       url: << parameters.url >>
       channel: << parameters.channel >>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
Old Slack notifications contained branch names, but new Slack notifications did not.

#### Example 1. Old slack notification
![image](https://user-images.githubusercontent.com/608755/90473904-02013e00-e15f-11ea-91d3-7b3e49ae3573.png)

#### Example 2. New Slack notification
![image](https://user-images.githubusercontent.com/608755/90474044-5f958a80-e15f-11ea-8331-fde85e500fdb.png)


### Description
Add `include_branch_field` to followings.

* command:  `approval`, `notify`, `notify-on-failure` and `status`
* job: `approval-notification`