### PR TITLE
Switched from webhook to oauth token to allow channel customization

### DIFF
--- a/src/commands/approval.yml
+++ b/src/commands/approval.yml
@@ -1,10 +1,11 @@
 description: Send a notification that a manual approval job is ready
 
 parameters:
-  webhook:
-    description: Enter either your Webhook value or use the CircleCI UI to add your token under the 'SLACK_WEBHOOK' env var
+  oauth_token:
     type: string
-    default: ${SLACK_WEBHOOK}
+    default: ${SLACK_OAUTH_TOKEN}
+    description: >
+      Enter either your 'Bot User OAuth Access Token' from Slack. The token should be available at https://api.slack.com/apps/A01AW6YH22J/oauth? or use the CircleCI UI to add your token under the 'SLACK_OAUTH_TOKEN' env var. Typically 'xoxb-##########-#############-************************'
 
   message:
     description: Enter custom message.
@@ -40,9 +41,9 @@ parameters:
 
   channel:
     type: string
-    default: ""
+    default: '#general'
     description: >
-      ID of channel if set, overrides webhook's default channel setting
+      Defaults to #general best to set this to a channel that does not have the entire org
 
 steps:
   - run:
@@ -64,9 +65,9 @@ steps:
       shell: /bin/bash
       command: |
         # Provide error if no webhook is set and error. Otherwise continue
-        if [ -z "<< parameters.webhook >>" ]; then
-          echo "NO SLACK WEBHOOK SET"
-          echo "Please input your SLACK_WEBHOOK value either in the settings for this project, or as a parameter for this orb."
+        if [ -z "<< parameters.oauth_token >>" ]; then
+          echo "NO SLACK OAuth Token SET"
+          echo "Please input your SLACK_OAUTH_TOKEN value either in the settings for this project, or as a parameter for this orb."
           exit 1
         else
           #Create Members string
@@ -84,6 +85,7 @@ steps:
           fi
 
           curl -X POST -H 'Content-type: application/json' \
+            -H 'Authorization: Bearer << parameters.oauth_token >>' \
             --data \
             "{ \
               <<# parameters.channel >>
@@ -119,6 +121,6 @@ steps:
                   \"color\": \"<< parameters.color >>\" \
                 } \
               ] \
-            }" << parameters.webhook >>
+            }" 'https://slack.com/api/chat.postMessage'
           echo "Awaiting approval notified."
         fi

--- a/src/commands/notify-on-failure.yml
+++ b/src/commands/notify-on-failure.yml
@@ -10,7 +10,21 @@ parameters:
       If set, a comma-separated list of branches for which to send
       notifications. No spaces.
 
+  oauth_token:
+    type: string
+    default: ${SLACK_OAUTH_TOKEN}
+    description: >
+      Enter either your 'Bot User OAuth Access Token' from Slack. The token should be available at https://api.slack.com/apps/A01AW6YH22J/oauth? or use the CircleCI UI to add your token under the 'SLACK_OAUTH_TOKEN' env var. Typically 'xoxb-##########-#############-************************'
+
+  channel:
+    type: string
+    default: '#general'
+    description: >
+      Defaults to #general best to set this to a channel that does not have the entire org
+
 steps:
   - status:
       fail_only: true
-      only_for_branches: <<parameters.only_for_branches>>
+      only_for_branches:  << parameters.only_for_branches >>
+      oauth_token:        << parameters.oauth_token >>
+      channel:            << parameters.channel >>

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -1,10 +1,11 @@
 description: Notify a Slack channel with a custom message
 
 parameters:
-  webhook:
-    description: Enter either your Webhook value or use the CircleCI UI to add your token under the 'SLACK_WEBHOOK' env var
+  oauth_token:
     type: string
-    default: ${SLACK_WEBHOOK}
+    default: ${SLACK_OAUTH_TOKEN}
+    description: >
+      Enter either your 'Bot User OAuth Access Token' from Slack. The token should be available at https://api.slack.com/apps/A01AW6YH22J/oauth? or use the CircleCI UI to add your token under the 'SLACK_OAUTH_TOKEN' env var. Typically 'xoxb-##########-#############-************************'
 
   message:
     description: Enter custom message.
@@ -73,9 +74,9 @@ parameters:
 
   channel:
     type: string
-    default: ""
+    default: '#general'
     description: >
-      ID of channel if set, overrides webhook's default channel setting
+      Defaults to #general best to set this to a channel that does not have the entire org
 
 steps:
   - run:
@@ -97,12 +98,12 @@ steps:
       shell: /bin/bash
       command: |
         # Provide error if no webhook is set and error. Otherwise continue
-        if [ -z "<< parameters.webhook >>" ]; then
-          echo "NO SLACK WEBHOOK SET"
-          echo "Please input your SLACK_WEBHOOK value either in the settings for this project, or as a parameter for this orb."
+        if [ -z "<< parameters.oauth_token >>" ]; then
+          echo "NO SLACK OAuth Token SET"
+          echo "Please input your SLACK_OAUTH_TOKEN value either in the settings for this project, or as a parameter for this orb."
           exit 1
         else
-          # Webhook properly set.
+          # oAuth Token properly set.
           echo Notifying Slack Channel
           #Create Members string
           if [ -n "<< parameters.mentions >>" ]; then
@@ -118,6 +119,7 @@ steps:
             done
           fi
           curl -X POST -H 'Content-type: application/json' \
+            -H 'Authorization: Bearer << parameters.oauth_token >>' \
             --data \
             "{ \
               <<# parameters.channel >>
@@ -162,5 +164,5 @@ steps:
                   \"color\": \"<< parameters.color >>\" \
                 } \
               ] \
-            }" << parameters.webhook >>
+            }" 'https://slack.com/api/chat.postMessage'
         fi

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -3,12 +3,11 @@ description: >
   Must be the last step in a job.
 
 parameters:
-  webhook:
+  oauth_token:
     type: string
-    default: ${SLACK_WEBHOOK}
+    default: ${SLACK_OAUTH_TOKEN}
     description: >
-      Enter either your Webhook value or use the CircleCI UI to add your
-      token under the 'SLACK_WEBHOOK' env var
+      Enter either your 'Bot User OAuth Access Token' from Slack. The token should be available at https://api.slack.com/apps/A01AW6YH22J/oauth? or use the CircleCI UI to add your token under the 'SLACK_OAUTH_TOKEN' env var. Typically 'xoxb-##########-#############-************************'
 
   success_message:
     type: string
@@ -65,9 +64,9 @@ parameters:
 
   channel:
     type: string
-    default: ""
+    default: '#general'
     description: >
-      ID of channel if set, overrides webhook's default channel setting
+      Defaults to #general best to set this to a channel that does not have the entire org
 
 steps:
   - run:
@@ -112,10 +111,10 @@ steps:
         done
 
         if [ "x" == "x<< parameters.only_for_branches>>" ] || [ "$current_branch_in_filter" = true ]; then
-          # Provide error if no webhook is set and error. Otherwise continue
-          if [ -z "<< parameters.webhook >>" ]; then
-            echo "NO SLACK WEBHOOK SET"
-            echo "Please input your SLACK_WEBHOOK value either in the settings for this project, or as a parameter for this orb."
+          # Provide error if no oAuth Token is set and error. Otherwise continue
+        if [ -z "<< parameters.oauth_token >>" ]; then
+          echo "NO SLACK OAuth Token SET"
+          echo "Please input your SLACK_OAUTH_TOKEN value either in the settings for this project, or as a parameter for this orb."
             exit 1
           else
             #Create Members string
@@ -139,6 +138,7 @@ steps:
                 echo '"fail_only" is set to "true". No Slack notification sent.'
               else
                 curl -X POST -H 'Content-type: application/json' \
+                  -H 'Authorization: Bearer << parameters.oauth_token >>' \
                   --data "{ \
                             <<# parameters.channel >>
                             \"channel\": \"<< parameters.channel >>\", \
@@ -175,7 +175,7 @@ steps:
                                 \"color\": \"#1CBF43\" \
                               } \
                             ] \
-                          } " << parameters.webhook >>
+                          } " 'https://slack.com/api/chat.postMessage'
                 echo "Job completed successfully. Alert sent."
               fi
             else
@@ -187,6 +187,7 @@ steps:
                 echo '"success_only" is set to "true". No Slack notification sent.'
               else
                 curl -X POST -H 'Content-type: application/json' \
+                  -H 'Authorization: Bearer << parameters.oauth_token >>' \
                   --data "{ \
                     <<# parameters.channel >>
                     \"channel\": \"<< parameters.channel >>\", \
@@ -223,7 +224,7 @@ steps:
                         \"color\": \"#ed5c5c\" \
                       } \
                     ] \
-                  } " << parameters.webhook >>
+                  } " 'https://slack.com/api/chat.postMessage'
                 echo "Job failed. Alert sent."
               fi
             fi

--- a/src/jobs/approval-notification.yml
+++ b/src/jobs/approval-notification.yml
@@ -1,10 +1,11 @@
 description: Notify Slack about an awaiting approval job
 
 parameters:
-  webhook:
-    description: Enter either your Webhook value or use the CircleCI UI to add your token under the 'SLACK_WEBHOOK' env var
+  oauth_token:
     type: string
-    default: ${SLACK_WEBHOOK}
+    default: ${SLACK_OAUTH_TOKEN}
+    description: >
+      Enter either your 'Bot User OAuth Access Token' from Slack. The token should be available at https://api.slack.com/apps/A01AW6YH22J/oauth? or use the CircleCI UI to add your token under the 'SLACK_OAUTH_TOKEN' env var. Typically 'xoxb-##########-#############-************************'
 
   message:
     description: Enter custom message.
@@ -40,15 +41,15 @@ parameters:
 
   channel:
     type: string
-    default: ""
+    default: '#general'
     description: >
-      ID of channel if set, overrides webhook's default channel setting
+      Defaults to #general best to set this to a channel that does not have the entire org
 
 executor: alpine
 
 steps:
   - approval:
-      webhook: << parameters.webhook >>
+      oauth_token: << parameters.oauth_token >>
       message: << parameters.message >>
       color: << parameters.color >>
       mentions: << parameters.mentions >>


### PR DESCRIPTION
I've got to update the documentation

This addresses https://github.com/CircleCI-Public/slack-orb/issues/77

 I've switched the code to use the app's oauth token as there is no longer a webhook I've defaulted the channel to `#general` as as it's the only one I can guarantee would be available in slack, so channel is effectively a mandatory field. 

The code has switched but I haven't amended the documentation. As this is a breaking change I'd like to get some feedback before I send time on the documentation. 
Please let me know if you'd be likely to accept this PR (and I'll go through the documentation), or if this is not a direction you want to take (and we can close this PR). 


### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
