### PR TITLE
Allow customising username & icon_emoji

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   orb-tools: circleci/orb-tools@8.27.3
-  slack: circleci/slack@dev:alpha
+  slack: circleci/slack@dev:staging
 
 jobs:
   notifytest:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Send a notification that a manual approval job is ready
 | `message` | `string` | A workflow in CircleCI is awaiting your approval. | Enter custom message. |
 | `url` | `string` | 'https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}' | The URL to link back to. |
 | `webhook` | `string` | '${SLACK_WEBHOOK}' | Enter either your Webhook value or use the CircleCI UI to add the webhook under the 'SLACK_WEBHOOK' env var |
+| `icon_emoji` | `string` | | Emoji to use for Slack message's avatar. Eg ":joy:". If unset, uses the webhook's default |
+| `username` | `string` | | Username to use for Slack message. Eg "CircleBot". If unset, uses the webhook's default |
 
 Example:
 
@@ -78,6 +80,8 @@ Notify a slack channel with a custom message at any point in a job with this cus
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
 | `include_visit_job_action` | `boolean` | `true` | Whether or not to include the _Visit Job_ action in the message |
 | `channel` | `string` | | ID of channel if set, overrides webhook's default channel setting |
+| `icon_emoji` | `string` | | Emoji to use for Slack message's avatar. Eg ":joy:". If unset, uses the webhook's default |
+| `username` | `string` | | Username to use for Slack message. Eg "CircleBot". If unset, uses the webhook's default |
 
 [Slack message attachment]: https://api.slack.com/docs/message-attachments
 
@@ -121,6 +125,8 @@ Send a status alert at the end of a job based on success or failure. This must b
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
 | `include_visit_job_action` | `boolean` | `true` | Whether or not to include the _Visit Job_ action in the message |
 | `channel` | `string` | | ID of channel if set, overrides webhook's default channel setting |
+| `icon_emoji` | `string` | | Emoji to use for Slack message's avatar. Eg ":joy:". If unset, uses the webhook's default |
+| `username` | `string` | | Username to use for Slack message. Eg "CircleBot". If unset, uses the webhook's default |
 
 Example:
 

--- a/src/commands/approval.yml
+++ b/src/commands/approval.yml
@@ -44,6 +44,18 @@ parameters:
     description: >
       ID of channel if set, overrides webhook's default channel setting
 
+  icon_emoji:
+    type: string
+    default: ""
+    description: >
+      Emoji to use for Slack message's avatar. Eg ":joy:". If unset, uses the webhook's default
+
+  username:
+    type: string
+    default: ""
+    description: >
+      Username to use for Slack message. Eg "CircleBot". If unset, uses the webhook's default
+
 steps:
   - run:
       name: Provide error if non-bash shell
@@ -89,6 +101,12 @@ steps:
               <<# parameters.channel >>
               \"channel\": \"<< parameters.channel >>\", \
               <</ parameters.channel >>
+              <<# parameters.icon_emoji >>
+              \"icon_emoji\": \"<< parameters.icon_emoji >>\", \
+              <</ parameters.icon_emoji >>
+              <<# parameters.username >>
+              \"username\": \"<< parameters.username >>\", \
+              <</ parameters.username >>
               \"attachments\": [ \
                 { \
                   \"fallback\": \"<< parameters.message >> - << parameters.url >>\", \

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -77,6 +77,18 @@ parameters:
     description: >
       ID of channel if set, overrides webhook's default channel setting
 
+  icon_emoji:
+    type: string
+    default: ""
+    description: >
+      Emoji to use for Slack message's avatar. Eg ":joy:". If unset, uses the webhook's default
+
+  username:
+    type: string
+    default: ""
+    description: >
+      Username to use for Slack message. Eg "CircleBot". If unset, uses the webhook's default
+
 steps:
   - run:
       name: Provide error if non-bash shell
@@ -123,6 +135,12 @@ steps:
               <<# parameters.channel >>
               \"channel\": \"<< parameters.channel >>\", \
               <</ parameters.channel >>
+              <<# parameters.icon_emoji >>
+              \"icon_emoji\": \"<< parameters.icon_emoji >>\", \
+              <</ parameters.icon_emoji >>
+              <<# parameters.username >>
+              \"username\": \"<< parameters.username >>\", \
+              <</ parameters.username >>
               \"attachments\": [ \
                 { \
                   \"fallback\": \"<< parameters.message >> - $CIRCLE_BUILD_URL\", \

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -69,6 +69,18 @@ parameters:
     description: >
       ID of channel if set, overrides webhook's default channel setting
 
+  icon_emoji:
+    type: string
+    default: ""
+    description: >
+      Emoji to use for Slack message's avatar. Eg ":joy:". If unset, uses the webhook's default
+
+  username:
+    type: string
+    default: ""
+    description: >
+      Username to use for Slack message. Eg "CircleBot". If unset, uses the webhook's default
+
 steps:
   - run:
       name: Provide error if curl is not installed.
@@ -143,6 +155,12 @@ steps:
                             <<# parameters.channel >>
                             \"channel\": \"<< parameters.channel >>\", \
                             <</ parameters.channel >>
+                            <<# parameters.icon_emoji >>
+                            \"icon_emoji\": \"<< parameters.icon_emoji >>\", \
+                            <</ parameters.icon_emoji >>
+                            <<# parameters.username >>
+                            \"username\": \"<< parameters.username >>\", \
+                            <</ parameters.username >>
                             \"attachments\": [ \
                               { \
                                 \"fallback\": \"<< parameters.success_message >>\", \
@@ -191,6 +209,12 @@ steps:
                     <<# parameters.channel >>
                     \"channel\": \"<< parameters.channel >>\", \
                     <</ parameters.channel >>
+                    <<# parameters.icon_emoji >>
+                    \"icon_emoji\": \"<< parameters.icon_emoji >>\", \
+                    <</ parameters.icon_emoji >>
+                    <<# parameters.username >>
+                    \"username\": \"<< parameters.username >>\", \
+                    <</ parameters.username >>
                     \"attachments\": [ \
                       { \
                         \"fallback\": \"<< parameters.failure_message >>\", \

--- a/src/jobs/approval-notification.yml
+++ b/src/jobs/approval-notification.yml
@@ -44,6 +44,18 @@ parameters:
     description: >
       ID of channel if set, overrides webhook's default channel setting
 
+  icon_emoji:
+    type: string
+    default: ""
+    description: >
+      Emoji to use for Slack message's avatar. Eg ":joy:". If unset, uses the webhook's default
+
+  username:
+    type: string
+    default: ""
+    description: >
+      Username to use for Slack message. Eg "CircleBot". If unset, uses the webhook's default
+
 executor: alpine
 
 steps:
@@ -56,3 +68,5 @@ steps:
       include_job_number_field: << parameters.include_job_number_field >>
       url: << parameters.url >>
       channel: << parameters.channel >>
+      icon_emoji: << parameters.icon_emoji >>
+      username: << parameters.username >>


### PR DESCRIPTION


### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] README has been updated, if necessary

### Motivation, issues

I understand you are working on a major rewrite of this project which will obsolete this change, but it is a very tiny QoL improvement with outsize return. I hope you consider merging soon 🙏  I am happy to re-do this work for the rewrite as well.

### Description

Support custom avatar & username for posted chat messages:
https://api.slack.com/methods/chat.postMessage

This allows you to customise the appearance of Slack messages. This isn't well documented, because Slack want everyone to move from incoming webhooks to apps. But it's 100% supported, and even allows using Workspace-specific emoji for avatars.