### PR TITLE
[semver:skip] fix: rename branch_filter parameter in example and script

### DIFF
--- a/src/examples/only_notify_on_branch.yml
+++ b/src/examples/only_notify_on_branch.yml
@@ -1,5 +1,5 @@
 description: >
-  Use the "branch_list" parameter to limit notifications to specified branches.
+  Use the "branch_pattern" parameter to limit notifications to specified branches.
   Useful when a job is executed on multiple branches but you only wish to be notified on a subset of branches.
   For example: If your "build" job runs on every branch, but you wish to only be notified when a failure occurs on the "staging" branch, your config may look like this.
 usage:
@@ -12,11 +12,11 @@ usage:
       steps:
         - run: some build command
         - slack/notify:
-            branch_list: main # a comma separated list of branches for which this notification will execute. By default, all branches will trigger.
+            branch_pattern: main # A comma separated list of regex matchable branch names. Notifications will only be sent if sent from a job from these branches. By default ".+" will be used to match all branches.
             event: fail
             template: basic_fail_1
         - slack/notify:
-            branch_list: production # A second alert to ping certain folks to failures on this branch.
+            branch_pattern: production # A second alert to ping certain folks to failures on this branch.
             event: fail
             template: basic_fail_1
             mentions: "<@U8XXXXXXX>, @UserName"

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -103,7 +103,7 @@ BranchFilter() {
         # dont send message.
         echo "NO SLACK ALERT"
         echo
-        echo 'Current branch does not match any item from the "branch_list" parameter'
+        echo 'Current branch does not match any item from the "branch_pattern" parameter'
         echo "Current branch: ${CIRCLE_BRANCH}"
         exit 0
     fi


### PR DESCRIPTION
* Updated example for `only_notify_on_branch` to reflect the `branch_pattern` parameter.
* Updated `BranchFilter()` function in `notify.sh` to log `branch_pattern` instead of the deprecated parameter.
* Closes #183 and #181.