### PR TITLE
[feat] include curl response in CI output [semver:patch]

### DIFF
--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -38,7 +38,7 @@ PostToSlack() {
         curl -s -f -X POST -H 'Content-type: application/json' \
         -H "Authorization: Bearer $SLACK_ACCESS_TOKEN" \
         --data \
-        "$SLACK_MSG_BODY" https://slack.com/api/chat.postMessage > /dev/null
+        "$SLACK_MSG_BODY" https://slack.com/api/chat.postMessage | jq '{ok: .ok, error: .error}'
     done
 }
 


### PR DESCRIPTION
See https://github.com/CircleCI-Public/slack-orb/issues/194

I found it challenging to debug the permission issues I experienced when integrating with the `slack-orb` notify command. I believe including the `curl` output in the console, or parsing the response and showing a helpful error  in the CI console may be worth considering.

Lemme know what you think. Many thanks 🙏