### PR TITLE
[semver:patch] Fix job status detection

### DIFF
--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -137,6 +137,7 @@ CheckEnvVars() {
 # This is done so this script may be tested.
 ORB_TEST_ENV="bats-core"
 if [ "${0#*$ORB_TEST_ENV}" = "$0" ]; then
+    . "/tmp/SLACK_JOB_STATUS" # this is required for fetching the job status set by the notify.yml command.
     CheckEnvVars
     InstallJq
     BuildMessageBody


### PR DESCRIPTION
Accidentally / erroneously removed this in a previous commit. Required for detecting job status. Repaired and added a comment for future reference.