### PR TITLE
Add basic_success_1.json template

### DIFF
--- a/src/message_templates/basic_success_1.json
+++ b/src/message_templates/basic_success_1.json
@@ -1,0 +1,60 @@
+{
+	"blocks": [
+		{
+			"type": "header",
+			"text": {
+				"type": "plain_text",
+				"text": "Job Succeeded. :green_circle:",
+				"emoji": true
+			}
+		},
+		{
+			"type": "section",
+			"fields": [
+				{
+					"type": "mrkdwn",
+					"text": "*Job*: ${CIRCLE_JOB}"
+				}
+			]
+		},
+		{
+			"type": "section",
+			"fields": [
+				{
+					"type": "mrkdwn",
+					"text": "*Project*:\\n$CIRCLE_PROJECT_REPONAME"
+				},
+				{
+					"type": "mrkdwn",
+					"text": "*Branch*:\\n$CIRCLE_BRANCH"
+                },
+                {
+					"type": "mrkdwn",
+					"text": "*Commit*:\\n$CIRCLE_SHA1"
+				},
+				{
+					"type": "mrkdwn",
+					"text": "*Author*:\\n$CIRCLE_USERNAME"
+				}
+			],
+			"accessory": {
+				"type": "image",
+				"image_url": "https://assets.brandfolder.com/otz5mn-bw4j2w-6jzqo8/original/circle-logo-badge-black.png",
+				"alt_text": "CircleCI logo"
+			}
+		},
+		{
+			"type": "actions",
+			"elements": [
+				{
+					"type": "button",
+					"text": {
+						"type": "plain_text",
+						"text": "View Job"
+					},
+					"url": "${CIRCLE_BUILD_URL}"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Matches other basic templates.

The existing `success_tagged_deploy_1.json` template isn't applicable to my workflows and shows an empty tags section.