### PR TITLE
Add text field for descriptive Slack notifications [semver:patch]

### DIFF
--- a/src/message_templates/basic_fail_1.json
+++ b/src/message_templates/basic_fail_1.json
@@ -1,4 +1,5 @@
 {
+	"text": "CircleCI job failed",
 	"blocks": [
 		{
 			"type": "header",

--- a/src/message_templates/basic_fail_1.json
+++ b/src/message_templates/basic_fail_1.json
@@ -1,5 +1,5 @@
 {
-	"text": "CircleCI job failed",
+	"text": "CircleCI job failed.",
 	"blocks": [
 		{
 			"type": "header",

--- a/src/message_templates/basic_on_hold_1.json
+++ b/src/message_templates/basic_on_hold_1.json
@@ -1,4 +1,5 @@
 {
+	"text": "CircleCI job on hold, waiting for approval.",
 	"blocks": [
 		{
 			"type": "header",

--- a/src/message_templates/basic_success_1.json
+++ b/src/message_templates/basic_success_1.json
@@ -1,4 +1,5 @@
 {
+	"text": "CircleCI job succeeded!",
 	"blocks": [
 		{
 			"type": "header",

--- a/src/message_templates/success_tagged_deploy_1.json
+++ b/src/message_templates/success_tagged_deploy_1.json
@@ -1,5 +1,5 @@
 {
-	"text": "",
+	"text": "CircleCI job succeeded!",
 	"blocks": [
 		{
 			"type": "header",


### PR DESCRIPTION
## Why?

Currently, Slack notifications for any messages sent by this Orb are displayed as follows

<img width="334" alt="Screenshot 2021-03-09 at 13 17 16" src="https://user-images.githubusercontent.com/5927420/110514979-c7152680-80ff-11eb-808c-76e0c575d172.png">

It makes for a bad user experience since their first notification from the Slack orb is an error message. 

## What?

This PR fixes the "_this content cant be displayed._" message to a more descriptive text. 

## How?

According to the Slack [docs](https://api.slack.com/messaging/composing/layouts#add_blocks_array), adding a `text` field when using `blocks` can prevent this message. 

> When you're using blocks in your message payload, the top-level text field becomes a fallback message displayed in notifications. Blocks should define everything else about the desired visible message.

