### PR TITLE
add event override parameter

### DIFF
--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -20,6 +20,11 @@ parameters:
     type: enum
     enum: ["fail", "pass", "always"]
     default: "always"
+  override_event:
+    description: |
+      Send message if environment variable is not empty and override event parameter.
+    type: string
+    default: ""
   branch_pattern:
     description: |
       A comma separated list of regex matchable branch names. Notifications will only be sent if sent from a job from these branches. By default ".+" will be used to match all branches. Pattern must match the full string, no partial matches.
@@ -71,6 +76,7 @@ steps:
         SLACK_PARAM_TAGPATTERN: "<<parameters.tag_pattern>>"
         SLACK_PARAM_CHANNEL: "<<parameters.channel>>"
         SLACK_PARAM_IGNORE_ERRORS: "<<parameters.ignore_errors>>"
+        SLACK_PARAM_OVERRIDE_EVENT: "<<parameters.override_event>>"
         # import pre-built templates using the orb-pack local script include.
         basic_fail_1: "<<include(message_templates/basic_fail_1.json)>>"
         success_tagged_deploy_1: "<<include(message_templates/success_tagged_deploy_1.json)>>"

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -122,7 +122,7 @@ CheckEnvVars() {
 }
 
 ShouldPost() {
-    if [ "$CCI_STATUS" = "$SLACK_PARAM_EVENT" ] || [ "$SLACK_PARAM_EVENT" = "always" ]; then
+    if [[ -n $(eval echo $SLACK_PARAM_OVERRIDE_EVENT) ]] || [ "$CCI_STATUS" = "$SLACK_PARAM_EVENT" ] || [ "$SLACK_PARAM_EVENT" = "always" ]; then
         # In the event the Slack notification would be sent, first ensure it is allowed to trigger
         # on this branch or this tag.
         FilterBy "$SLACK_PARAM_BRANCHPATTERN" "${CIRCLE_BRANCH:-}"


### PR DESCRIPTION
CircleCi provide no way to run steps based on dynamic condition to run jobs in a workflow. If you want to only run "slack-notify" for a specific case you need to [export an environment variable and use it in next steps](https://circleci.com/docs/2.0/env-vars/#example-configuration-of-environment-variables). This PR allow user to pass an environment variable to trigger the slack notify and override current event parameter check.

edit: without this PR there is no way to send slack notification other than "always" , or when job fail or succeed.