### PR TITLE
Check for SLACK_WEBHOOK before SLACK_ACCESS_TOKEN [semver:patch]

### DIFF
--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -104,6 +104,11 @@ FilterBy() {
 }
 
 CheckEnvVars() {
+    if [ -n "${SLACK_WEBHOOK:-}" ]; then
+        echo "It appears you have a Slack Webhook token present in this job."
+        echo "Please note, Webhooks are no longer used for the Slack Orb (v4 +)."
+        echo "Follow the setup guide available in the wiki: https://github.com/CircleCI-Public/slack-orb/wiki/Setup"
+    fi
     if [ -z "${SLACK_ACCESS_TOKEN:-}" ]; then
         echo "In order to use the Slack Orb (v4 +), an OAuth token must be present via the SLACK_ACCESS_TOKEN environment variable."
         echo "Follow the setup guide available in the wiki: https://github.com/CircleCI-Public/slack-orb/wiki/Setup"
@@ -113,11 +118,6 @@ CheckEnvVars() {
     if [ -z "${SLACK_PARAM_CHANNEL:-}" ]; then
        echo "No channel was provided. Enter value for SLACK_DEFAULT_CHANNEL env var, or channel parameter"
        exit 1
-    fi
-    if [ -n "${SLACK_WEBHOOK:-}" ]; then
-        echo "It appears you have a Slack Webhook token present in this job."
-        echo "Please note, Webhooks are no longer used for the Slack Orb (v4 +)."
-        echo "Follow the setup guide available in the wiki: https://github.com/CircleCI-Public/slack-orb/wiki/Setup"
     fi
 }
 


### PR DESCRIPTION
`SLACK_WEBHOOK` is no longer supported; instead, `SLACK_ACCESS_TOKEN` and `SLACK_PARAM_CHANNEL` are used. We've been checking for those first, and bailing if they're not found. But people upgrading to 4.x won't understand the error they see about a missing `SLACK_ACCESS_TOKEN`.

Instead, check for and warn about `SLACK_WEBHOOK` first to make it clear why more setup is required.

(Source: Tried to upgrade, was confused. 😉 )