### PR TITLE
Update slack orb examples documentation

### DIFF
--- a/src/examples/custom_notification.yml
+++ b/src/examples/custom_notification.yml
@@ -6,7 +6,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.1
+    slack: circleci/slack@4.4.4
   jobs:
     notify:
       docker:

--- a/src/examples/custom_notification.yml
+++ b/src/examples/custom_notification.yml
@@ -6,7 +6,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.4.4
+    slack: circleci/slack@4.4
   jobs:
     notify:
       docker:

--- a/src/examples/full_deployment_sample.yml
+++ b/src/examples/full_deployment_sample.yml
@@ -5,7 +5,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.1
+    slack: circleci/slack@4.4.4
   jobs:
     # This "test" job will run on every commit (as per our workflow)
     # We are ok with no notifications sent for this job.

--- a/src/examples/full_deployment_sample.yml
+++ b/src/examples/full_deployment_sample.yml
@@ -5,7 +5,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.4.4
+    slack: circleci/slack@4.4
   jobs:
     # This "test" job will run on every commit (as per our workflow)
     # We are ok with no notifications sent for this job.

--- a/src/examples/notify_on_fail_with_template.yml
+++ b/src/examples/notify_on_fail_with_template.yml
@@ -6,7 +6,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.4.4
+    slack: circleci/slack@4.4
     node: circleci/node@4.7.0
   jobs:
     deploy:

--- a/src/examples/notify_on_fail_with_template.yml
+++ b/src/examples/notify_on_fail_with_template.yml
@@ -6,7 +6,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.1
+    slack: circleci/slack@4.4.4
     node: circleci/node:4.1
   jobs:
     deploy:

--- a/src/examples/notify_on_fail_with_template.yml
+++ b/src/examples/notify_on_fail_with_template.yml
@@ -7,7 +7,7 @@ usage:
   version: 2.1
   orbs:
     slack: circleci/slack@4.4.4
-    node: circleci/node:4.1
+    node: circleci/node@4.7.0
   jobs:
     deploy:
       executor:

--- a/src/examples/notify_on_fail_with_template.yml
+++ b/src/examples/notify_on_fail_with_template.yml
@@ -7,7 +7,7 @@ usage:
   version: 2.1
   orbs:
     slack: circleci/slack@4.4
-    node: circleci/node@4.7.0
+    node: circleci/node@4.7
   jobs:
     deploy:
       executor:

--- a/src/examples/notify_two_channels.yml
+++ b/src/examples/notify_two_channels.yml
@@ -9,7 +9,7 @@ usage:
   version: 2.1
   orbs:
     slack: circleci/slack@4.4
-    node: circleci/node@4.7.0
+    node: circleci/node@4.7
   jobs:
     deploy:
       executor:

--- a/src/examples/notify_two_channels.yml
+++ b/src/examples/notify_two_channels.yml
@@ -9,7 +9,7 @@ usage:
   version: 2.1
   orbs:
     slack: circleci/slack@4.4.4
-    node: circleci/node:4.1
+    node: circleci/node@4.7.0
   jobs:
     deploy:
       executor:

--- a/src/examples/notify_two_channels.yml
+++ b/src/examples/notify_two_channels.yml
@@ -8,7 +8,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.4.4
+    slack: circleci/slack@4.4
     node: circleci/node@4.7.0
   jobs:
     deploy:

--- a/src/examples/notify_two_channels.yml
+++ b/src/examples/notify_two_channels.yml
@@ -8,7 +8,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.1
+    slack: circleci/slack@4.4.4
     node: circleci/node:4.1
   jobs:
     deploy:

--- a/src/examples/on_hold_notification.yml
+++ b/src/examples/on_hold_notification.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.4.4
+    slack: circleci/slack@4.4
   workflows:
     on-hold-example:
       jobs:

--- a/src/examples/on_hold_notification.yml
+++ b/src/examples/on_hold_notification.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.1
+    slack: circleci/slack@4.4.4
   workflows:
     on-hold-example:
       jobs:

--- a/src/examples/only_notify_on_branch.yml
+++ b/src/examples/only_notify_on_branch.yml
@@ -5,7 +5,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.1
+    slack: circleci/slack@4.4.4
   jobs:
     build:
       machine: true

--- a/src/examples/only_notify_on_branch.yml
+++ b/src/examples/only_notify_on_branch.yml
@@ -5,7 +5,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.4.4
+    slack: circleci/slack@4.4
   jobs:
     build:
       machine: true

--- a/src/examples/successful_tagged_deployment.yml
+++ b/src/examples/successful_tagged_deployment.yml
@@ -6,7 +6,7 @@ usage:
   version: 2.1
   orbs:
     slack: circleci/slack@4.4
-    node: circleci/node@4.7.0
+    node: circleci/node@4.7
   jobs:
     deploy:
       executor:

--- a/src/examples/successful_tagged_deployment.yml
+++ b/src/examples/successful_tagged_deployment.yml
@@ -5,7 +5,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.4.4
+    slack: circleci/slack@4.4
     node: circleci/node@4.7.0
   jobs:
     deploy:

--- a/src/examples/successful_tagged_deployment.yml
+++ b/src/examples/successful_tagged_deployment.yml
@@ -5,7 +5,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.1
+    slack: circleci/slack@4.4.4
     node: circleci/node:4.1
   jobs:
     deploy:

--- a/src/examples/successful_tagged_deployment.yml
+++ b/src/examples/successful_tagged_deployment.yml
@@ -6,7 +6,7 @@ usage:
   version: 2.1
   orbs:
     slack: circleci/slack@4.4.4
-    node: circleci/node:4.1
+    node: circleci/node@4.7.0
   jobs:
     deploy:
       executor:


### PR DESCRIPTION
These commits will update the documentation for the examples as used by the Slack Orb to update how the node orb version is declared and update the versions of the Slack and Node orb themselves to be accurate against the current Orb versions.