### PR TITLE
[semver:patch] fix: update basic success newline escaping

### DIFF
--- a/src/message_templates/basic_success_1.json
+++ b/src/message_templates/basic_success_1.json
@@ -23,19 +23,19 @@
 			"fields": [
 				{
 					"type": "mrkdwn",
-					"text": "*Project*:\n $CIRCLE_PROJECT_REPONAME"
+					"text": "*Project*:\\n $CIRCLE_PROJECT_REPONAME"
 				},
 				{
 					"type": "mrkdwn",
-					"text": "*Branch*:\n $CIRCLE_BRANCH"
-                },
-                {
-					"type": "mrkdwn",
-					"text": "*Commit*:\n $CIRCLE_SHA1"
+					"text": "*Branch*:\\n $CIRCLE_BRANCH"
 				},
 				{
 					"type": "mrkdwn",
-					"text": "*Author*:\n $CIRCLE_USERNAME"
+					"text": "*Commit*:\\n $CIRCLE_SHA1"
+				},
+				{
+					"type": "mrkdwn",
+					"text": "*Author*:\\n $CIRCLE_USERNAME"
 				}
 			],
 			"accessory": {


### PR DESCRIPTION
The basic_success_1 template doesn't escape newlines properly. Update it
to match the others (basically `s/\n/\\n/`). I see it was like this at
one point, but then the `\\n` were changed to `\n` at some point. I'm
guessing since we don't have problems with the other templates and they
all use the `\\n` format, that it should be using `\\n`.

maybe
Fixes #255