### PR TITLE
(RE-1507) Add explicit $BASH_ENV execution

### DIFF
--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -144,6 +144,7 @@ ShouldPost() {
 # This is done so this script may be tested.
 ORB_TEST_ENV="bats-core"
 if [ "${0#*$ORB_TEST_ENV}" = "$0" ]; then
+    # shellcheck disable=SC1090
     . $BASH_ENV
     CheckEnvVars
     . "/tmp/SLACK_JOB_STATUS"

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -104,6 +104,17 @@ FilterBy() {
     fi
 }
 
+SetupEnvVars() {
+    echo "BASH_ENV file: $BASH_ENV"
+    if [ -f "$BASH_ENV" ]; then
+        echo "Exists. Sourcing into ENV"
+        # shellcheck disable=SC1090
+        . $BASH_ENV
+    else
+        echo "Does Not Exist. Skipping file execution"
+    fi
+}
+
 CheckEnvVars() {
     if [ -n "${SLACK_WEBHOOK:-}" ]; then
         echo "It appears you have a Slack Webhook token present in this job."
@@ -144,8 +155,7 @@ ShouldPost() {
 # This is done so this script may be tested.
 ORB_TEST_ENV="bats-core"
 if [ "${0#*$ORB_TEST_ENV}" = "$0" ]; then
-    # shellcheck disable=SC1090
-    . $BASH_ENV
+    SetupEnvVars
     CheckEnvVars
     . "/tmp/SLACK_JOB_STATUS"
     ShouldPost

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -144,6 +144,7 @@ ShouldPost() {
 # This is done so this script may be tested.
 ORB_TEST_ENV="bats-core"
 if [ "${0#*$ORB_TEST_ENV}" = "$0" ]; then
+    . $BASH_ENV
     CheckEnvVars
     . "/tmp/SLACK_JOB_STATUS"
     ShouldPost


### PR DESCRIPTION
![](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ffilmdaily.co%2Fwp-content%2Fuploads%2F2020%2F06%2Fmeme-08.gif&f=1&nofb=1)

When calling slack notify via the orb or in a command, using `$BASH_ENV` doesn't seem to work. Adding this explicit call lets others continue to customize the command via `$BASH_ENV` and have those customizations change the slack behavior.

Testing Results (links internal to CircleCI org):

- [job](https://app.circleci.com/pipelines/github/circleci/server/21570/workflows/40b18d91-30b6-4b4b-bfbd-555542335cc1/jobs/75332) (defined in [this branch](https://github.com/circleci/server/compare/main...repro/RE-1507)) showing the `$SLACK_PARAM_MENTIONS` being set in `$BASH_ENV`, but not being read by the `slack/notify` command correctly for the [slack post]()
- [job](https://app.circleci.com/pipelines/github/circleci/server/21821/workflows/3c823a3c-e5d9-447a-814d-a7ba035d1cf7/jobs/76872) showing this fix being passed the `$SLACK_PARAM_MENTIONS` & printing the value after running the `$BASH_ENV` explicitly

Please let me know if there's anything I need or missed for this PR, I'm having trouble finding a contributor doc or guides.