### PR TITLE
[semver: patch] fixed extra literal \n in slack message templates

### DIFF
--- a/src/message_templates/basic_fail_1.json
+++ b/src/message_templates/basic_fail_1.json
@@ -23,15 +23,15 @@
 			"fields": [
 				{
 					"type": "mrkdwn",
-					"text": "*Project*:\\n$CIRCLE_PROJECT_REPONAME"
+					"text": "*Project*: $CIRCLE_PROJECT_REPONAME"
 				},
 				{
 					"type": "mrkdwn",
-					"text": "*Branch*:\\n$CIRCLE_BRANCH"
+					"text": "*Branch*: $CIRCLE_BRANCH"
 				},
 				{
 					"type": "mrkdwn",
-					"text": "*Author*:\\n$CIRCLE_USERNAME"
+					"text": "*Author*: $CIRCLE_USERNAME"
 				}
 			],
 			"accessory": {
@@ -45,7 +45,7 @@
 			"fields": [
 				{
 					"type": "mrkdwn",
-					"text": "*Mentions*:\\n$SLACK_PARAM_MENTIONS"
+					"text": "*Mentions*: $SLACK_PARAM_MENTIONS"
 				}
 			]
 		},

--- a/src/message_templates/basic_on_hold_1.json
+++ b/src/message_templates/basic_on_hold_1.json
@@ -14,15 +14,15 @@
 			"fields": [
 				{
 					"type": "mrkdwn",
-					"text": "*Project*:\\n$CIRCLE_PROJECT_REPONAME"
+					"text": "*Project*: $CIRCLE_PROJECT_REPONAME"
 				},
 				{
 					"type": "mrkdwn",
-					"text": "*Branch*:\\n$CIRCLE_BRANCH"
+					"text": "*Branch*: $CIRCLE_BRANCH"
 				},
 				{
 					"type": "mrkdwn",
-					"text": "*Author*:\\n$CIRCLE_USERNAME"
+					"text": "*Author*: $CIRCLE_USERNAME"
 				}
 			],
 			"accessory": {
@@ -36,7 +36,7 @@
 			"fields": [
 				{
 					"type": "mrkdwn",
-					"text": "*Mentions*:\\n$SLACK_PARAM_MENTIONS"
+					"text": "*Mentions*: $SLACK_PARAM_MENTIONS"
 				}
 			]
 		},

--- a/src/message_templates/basic_success_1.json
+++ b/src/message_templates/basic_success_1.json
@@ -23,19 +23,19 @@
 			"fields": [
 				{
 					"type": "mrkdwn",
-					"text": "*Project*:\\n $CIRCLE_PROJECT_REPONAME"
+					"text": "*Project*: $CIRCLE_PROJECT_REPONAME"
 				},
 				{
 					"type": "mrkdwn",
-					"text": "*Branch*:\\n $CIRCLE_BRANCH"
+					"text": "*Branch*: $CIRCLE_BRANCH"
 				},
 				{
 					"type": "mrkdwn",
-					"text": "*Commit*:\\n $CIRCLE_SHA1"
+					"text": "*Commit*: $CIRCLE_SHA1"
 				},
 				{
 					"type": "mrkdwn",
-					"text": "*Author*:\\n $CIRCLE_USERNAME"
+					"text": "*Author*: $CIRCLE_USERNAME"
 				}
 			],
 			"accessory": {
@@ -49,7 +49,7 @@
 			"fields": [
 				{
 					"type": "mrkdwn",
-					"text": "*Mentions*:\\n$SLACK_PARAM_MENTIONS"
+					"text": "*Mentions*: $SLACK_PARAM_MENTIONS"
 				}
 			]
 		},

--- a/src/message_templates/success_tagged_deploy_1.json
+++ b/src/message_templates/success_tagged_deploy_1.json
@@ -14,15 +14,15 @@
 			"fields": [
 				{
 					"type": "mrkdwn",
-					"text": "*Project*:\\n$CIRCLE_PROJECT_REPONAME"
+					"text": "*Project*: $CIRCLE_PROJECT_REPONAME"
 				},
 				{
 					"type": "mrkdwn",
-					"text": "*When*:\\n$(date +'%m/%d/%Y %T')"
+					"text": "*When*: $(date +'%m/%d/%Y %T')"
 				},
 				{
 					"type": "mrkdwn",
-					"text": "*Tag*:\\n$CIRCLE_TAG"
+					"text": "*Tag*: $CIRCLE_TAG"
 				}
 			],
 			"accessory": {


### PR DESCRIPTION
fixed extra literal \n in slack message templates