### PR TITLE
Feat: Add environment variable support to the "mentions" parameter [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,12 +62,20 @@ jobs:
           name: Verify SLACK_JOB_STATUS is written
           command: |
             grep "pass" /tmp/SLACK_JOB_STATUS
+      - run:
+          name: Export mention variable
+          command: |
+            'export MY_MENTION=@orbs, everything looks good here!' >> $BASH_ENV
       - slack/notify:
           template: basic_fail_1
           mentions: "@orbs"
           event: always
       - slack/notify:
           template: basic_success_1
+          event: always
+      - slack/notify:
+          template: basic_success_1
+          mentions: "$MY_MENTION"
           event: always
       - slack/notify:
           template: success_tagged_deploy_1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
             grep "pass" /tmp/SLACK_JOB_STATUS
       - run:
           name: Export mention variable
-          command: echo 'export MY_MENTION=@orbs, everything looks good here!' >> $BASH_ENV
+          command: echo 'export MY_MENTION="@orbs, everything looks good here!"' >> $BASH_ENV
       - slack/notify:
           template: basic_fail_1
           mentions: "@orbs"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,8 +64,7 @@ jobs:
             grep "pass" /tmp/SLACK_JOB_STATUS
       - run:
           name: Export mention variable
-          command: |
-            'export MY_MENTION=@orbs, everything looks good here!' >> $BASH_ENV
+          command: echo 'export MY_MENTION=@orbs, everything looks good here!' >> $BASH_ENV
       - slack/notify:
           template: basic_fail_1
           mentions: "@orbs"

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -25,10 +25,10 @@ BuildMessageBody() {
 
         SLACK_PARAM_MENTIONS_VALUE=$(echo $T2 | jq -r '.blocks[] | select(.type == "section").fields[].text | select(contains("Mentions"))' | sed -e "s/\*Mentions\*: //")
         # Checking if the string might contain an environment variable.
-        if [[ "$SLACK_PARAM_MENTIONS_VALUE" == *"\$"* ]]; then
+        if [ "$SLACK_PARAM_MENTIONS_VALUE" == *"\$"* ]; then
         
             # If there is a "$" and no mentions with "@" we assume it's an environment variable, expanded it and update the json
-            if [[ "$SLACK_PARAM_MENTIONS_VALUE" != *"@"* ]]; then
+            if [ "$SLACK_PARAM_MENTIONS_VALUE" != *"@"* ]; then
                 EXPANDED_MENTION=$(eval echo "$SLACK_PARAM_MENTIONS_VALUE")
                 T2=$(echo $T2 | jq -r --arg mentions "*Mentions*: $EXPANDED_MENTION" \
                     '(.blocks[] | select(.type == "section").fields[].text | select(contains("Mentions"))) = $mentions')

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -19,10 +19,9 @@ BuildMessageBody() {
         echo "!!!!!!!! T1 !!!!!!!"
         echo $T1
 
+        T2=$(eval echo \""$T1"\")
         echo "!!!!!!!! T2 !!!!!!!"
         echo $T2
-        
-        T2=$(eval echo \""$T1"\")
     else
         echo "Error: No message template selected."
         echo "Select either a custom template or one of the pre-included ones via the 'custom' or 'template' parameters."

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -21,7 +21,7 @@ BuildMessageBody() {
             # If there is a "$" and no "@", we assume the string is an environment variable, expanded it and update the json
             if ! echo "$SLACK_PARAM_MENTIONS_VALUE" | grep -q "@" > /dev/null
             then
-                echo "Expading the environment variable: ${$SLACK_PARAM_MENTIONS_VALUE}"
+                echo "Expading the environment variable: $SLACK_PARAM_MENTIONS_VALUE"
                 EXPANDED_MENTION=$(eval echo "$SLACK_PARAM_MENTIONS_VALUE")
                 T2=$(echo $T2 | jq -r --arg mentions "*Mentions*: $EXPANDED_MENTION" \
                     '(.blocks[] | select(.type == "section").fields[].text | select(contains("Mentions"))) = $mentions')

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -10,8 +10,18 @@ BuildMessageBody() {
         T2=$(eval echo \""$CUSTOM_BODY_MODIFIED"\")
     elif [ -n "${SLACK_PARAM_TEMPLATE:-}" ]; then
         TEMPLATE="\$$SLACK_PARAM_TEMPLATE"
+
+        echo "!!!!!!!!!!!!!! TEMPLATE !!!!!!!!!!!!!!!"
+        echo $TEMPLATE
         # shellcheck disable=SC2016
         T1=$(eval echo "$TEMPLATE" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed 's/`/\\`/g')
+
+        echo "!!!!!!!! T1 !!!!!!!"
+        echo $T1
+
+        echo "!!!!!!!! T2 !!!!!!!"
+        echo $T2
+        
         T2=$(eval echo \""$T1"\")
     else
         echo "Error: No message template selected."

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -25,10 +25,11 @@ BuildMessageBody() {
 
         SLACK_PARAM_MENTIONS_VALUE=$(echo $T2 | jq -r '.blocks[] | select(.type == "section").fields[].text | select(contains("Mentions"))' | sed -e "s/\*Mentions\*: //")
         # Checking if the string might contain an environment variable.
-        if [ "$SLACK_PARAM_MENTIONS_VALUE" == *"\$"* ]; then
-        
-            # If there is a "$" and no mentions with "@" we assume it's an environment variable, expanded it and update the json
-            if [ "$SLACK_PARAM_MENTIONS_VALUE" != *"@"* ]; then
+        if echo "$SLACK_PARAM_MENTIONS_VALUE" | grep -q "$" > /dev/null
+        then
+            # If there is a "$" and no strings with "@" we assume it's an environment variable, expanded it and update the json
+            if ! echo "$SLACK_PARAM_MENTIONS_VALUE" | grep -q "@" > /dev/null
+            then
                 EXPANDED_MENTION=$(eval echo "$SLACK_PARAM_MENTIONS_VALUE")
                 T2=$(echo $T2 | jq -r --arg mentions "*Mentions*: $EXPANDED_MENTION" \
                     '(.blocks[] | select(.type == "section").fields[].text | select(contains("Mentions"))) = $mentions')

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -16,10 +16,10 @@ BuildMessageBody() {
         SLACK_PARAM_MENTIONS_VALUE=$(echo $T2 | jq -r '.blocks[] | select(.type == "section").fields[].text | select(contains("Mentions"))' | sed -e "s/\*Mentions\*: //")
 
         # Checking if the string might contain an environment variable.
-        if echo "$SLACK_PARAM_MENTIONS_VALUE" | grep -q "$" > /dev/null
+        if echo "$SLACK_PARAM_MENTIONS_VALUE" | grep -q -F "$" > /dev/null
         then
             # If there is a "$" and no "@", we assume the string is an environment variable, expanded it and update the json
-            if ! echo "$SLACK_PARAM_MENTIONS_VALUE" | grep -q "@" > /dev/null
+            if ! echo "$SLACK_PARAM_MENTIONS_VALUE" | grep -q -F "@" > /dev/null
             then
                 echo "Expading the environment variable: $SLACK_PARAM_MENTIONS_VALUE"
                 EXPANDED_MENTION=$(eval echo "$SLACK_PARAM_MENTIONS_VALUE")


### PR DESCRIPTION
As [proposed](https://github.com/CircleCI-Public/slack-orb/pull/311#issuecomment-988205044) in the PR #311, this change adds support for an environment variable in the [mentions](https://github.com/CircleCI-Public/slack-orb/blob/master/src/commands/notify.yml#L33) parameter.

Acceptable arguments now are:

- Environment variable
```
      - slack/notify:
          template: basic_success_1
          mentions: "$MY_MENTION"
          event: always

```

- Direct mention:
```
- slack/notify:
          template: basic_fail_1
          mentions: "@orbs"
          event: always
```

- Empty
```
      - slack/notify:
          template: basic_success_1
          event: always
```

Since we need a way to differentiate direct mentions from env variables, the env variable parameter has to contain the "$" (dollar sign).

