### PR TITLE
Chore: Updated "template" parameter description to make its function more clear [semver:patch]

### DIFF
--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -2,7 +2,10 @@ description: Notify a Slack channel with a custom message.
 
 parameters:
   template:
-    description: "Use one of the built-in templates. Select the template name. Preview each template on the gitHub Readme: "
+    description: |
+      Select which template to use for the notification by its name. The name must be available as an environment variable.
+      The built-in templates can be found and previewed at: https://github.com/CircleCI-Public/slack-orb/wiki#templates.
+      Alternatively, you can create and use your own dynamic templates: https://github.com/CircleCI-Public/slack-orb/wiki/Dynamic-Templates.
     type: string
     default: ""
   custom:


### PR DESCRIPTION
Per @chrisbruford's [suggestion](https://github.com/CircleCI-Public/slack-orb/issues/219#issuecomment-758829230) in #219, this change will make it a little more clear what is expected in the _template_ parameter. I am also including the built-in templates wiki and dynamic template links for users to reference.