### PR TITLE
Feat: Provide additional logging for debugging issues [semver:minor]

### DIFF
--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -148,15 +148,16 @@ ShouldPost() {
     fi
 }
 
-SetupLogs()) {
+SetupLogs() {
     $SUDO mkdir -p $LOG_PATH
-    echo "[]" | $SUDO tee $LOG_PATH/SLACK_SENT_RESPONSE_LOG.txt
+    echo "[]" | $SUDO tee $LOG_PATH/$SLACK_SENT_RESPONSE_LOG
 }
 
 # Will not run if sourced from another script.
 # This is done so this script may be tested.
 ORB_TEST_ENV="bats-core"
 if [ "${0#*$ORB_TEST_ENV}" = "$0" ]; then
+    SetupLogs
     CheckEnvVars
     . "/tmp/SLACK_JOB_STATUS"
     ShouldPost

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -152,10 +152,8 @@ ShouldPost() {
 }
 
 PrepareEnvinronment() {
-    if [ -L "$LOG_PATH" ]; then
-        $SUDO mkdir -p $LOG_PATH
-        $SUDO chmod -x $LOG_PATH
-    fi
+    $SUDO mkdir -p $LOG_PATH
+    $SUDO chmod -x $LOG_PATH
 }
 
 # Will not run if sourced from another script.

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -1,3 +1,5 @@
+if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
+
 LOG_PATH=/tmp/slack-orb/logs
 
 BuildMessageBody() {
@@ -151,7 +153,7 @@ ShouldPost() {
 
 PrepareEnvinronment() {
     if [ -L "$LOG_PATH" ]; then
-        mkdir -p LOG_PATH
+        $SUDO mkdir -p LOG_PATH
     fi
 }
 

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -27,7 +27,6 @@ BuildMessageBody() {
     SLACK_MSG_BODY=$T2
 }
 
-
 PostToSlack() {
     # Post once per channel listed by the channel parameter
     #    The channel must be modified in SLACK_MSG_BODY
@@ -168,5 +167,4 @@ if [ "${0#*$ORB_TEST_ENV}" = "$0" ]; then
     InstallJq
     BuildMessageBody
     PostToSlack
-
 fi

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -40,8 +40,8 @@ PostToSlack() {
             echo "The message body being sent to Slack is: $SLACK_MSG_BODY"
         fi
         SLACK_SENT_RESPONSE=$(curl -s -f -X POST -H 'Content-type: application/json' -H "Authorization: Bearer $SLACK_ACCESS_TOKEN" --data "$SLACK_MSG_BODY" https://slack.com/api/chat.postMessage)
-        $SUDO mkdir -p $LOG_PATH
-        $SUDO echo SLACK_SENT_RESPONSE > $LOG_PATH/SLACK_SENT_RESPONSE_LOG.txt
+        # $SUDO mkdir -p $LOG_PATH
+        $SUDO echo SLACK_SENT_RESPONSE > $LOG_PATH/$SLACK_SENT_RESPONSE_LOG.txt
         if [ -n "${SLACK_PARAM_DEBUG:-}" ]; then
             echo "The response from the API call to slack is : $SLACK_SENT_RESPONSE"
         fi        
@@ -154,6 +154,7 @@ ShouldPost() {
 PrepareEnvinronment() {
     if [ -L "$LOG_PATH" ]; then
         $SUDO mkdir -p $LOG_PATH
+        $SUDO chmod -x $LOG_PATH
     fi
 }
 

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -1,6 +1,3 @@
-LOG_PATH=/tmp/slack-orb/logs
-mkdir -p LOG_PATH
-
 BuildMessageBody() {
     # Send message
     #   If sending message, default to custom template,
@@ -150,10 +147,19 @@ ShouldPost() {
     fi
 }
 
+PrepareEnvinronment() {
+    LOG_PATH=/tmp/slack-orb/logs
+
+    if [ -L "$dirname" ]; then
+        mkdir -p LOG_PATH
+    fi
+}
+
 # Will not run if sourced from another script.
 # This is done so this script may be tested.
 ORB_TEST_ENV="bats-core"
 if [ "${0#*$ORB_TEST_ENV}" = "$0" ]; then
+    PrepareEnvinronment
     CheckEnvVars
     . "/tmp/SLACK_JOB_STATUS"
     ShouldPost

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -1,3 +1,5 @@
+LOG_PATH=/tmp/slack-orb/logs
+
 BuildMessageBody() {
     # Send message
     #   If sending message, default to custom template,
@@ -148,9 +150,7 @@ ShouldPost() {
 }
 
 PrepareEnvinronment() {
-    LOG_PATH=/tmp/slack-orb/logs
-
-    if [ -L "$dirname" ]; then
+    if [ -L "$LOG_PATH" ]; then
         mkdir -p LOG_PATH
     fi
 }

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -151,7 +151,7 @@ ShouldPost() {
 SetupLogs() {
     $SUDO mkdir -p $LOG_PATH
 
-    if [ -f "$LOG_PATH/$SLACK_SENT_RESPONSE_LOG" ]; then
+    if [ ! -f "$LOG_PATH/$SLACK_SENT_RESPONSE_LOG" ]; then
         echo "[]" | $SUDO tee $LOG_PATH/$SLACK_SENT_RESPONSE_LOG
     fi
 }

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -150,7 +150,10 @@ ShouldPost() {
 
 SetupLogs() {
     $SUDO mkdir -p $LOG_PATH
-    echo "[]" | $SUDO tee $LOG_PATH/$SLACK_SENT_RESPONSE_LOG
+
+    if [ -f "$LOG_PATH/$SLACK_SENT_RESPONSE_LOG" ]; then
+        echo "[]" | $SUDO tee $LOG_PATH/$SLACK_SENT_RESPONSE_LOG
+    fi
 }
 
 # Will not run if sourced from another script.

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -41,7 +41,7 @@ PostToSlack() {
         fi
         SLACK_SENT_RESPONSE=$(curl -s -f -X POST -H 'Content-type: application/json' -H "Authorization: Bearer $SLACK_ACCESS_TOKEN" --data "$SLACK_MSG_BODY" https://slack.com/api/chat.postMessage)
         $SUDO mkdir -p $LOG_PATH
-        echo SLACK_SENT_RESPONSE > $LOG_PATH/SLACK_SENT_RESPONSE_LOG.txt
+        $SUDO echo SLACK_SENT_RESPONSE > $LOG_PATH/SLACK_SENT_RESPONSE_LOG.txt
         if [ -n "${SLACK_PARAM_DEBUG:-}" ]; then
             echo "The response from the API call to slack is : $SLACK_SENT_RESPONSE"
         fi        

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -1,4 +1,5 @@
 LOG_PATH=/tmp/slack-orb/logs
+mkdir -p LOG_PATH
 
 BuildMessageBody() {
     # Send message
@@ -153,7 +154,6 @@ ShouldPost() {
 # This is done so this script may be tested.
 ORB_TEST_ENV="bats-core"
 if [ "${0#*$ORB_TEST_ENV}" = "$0" ]; then
-    mkdir -p LOG_PATH
     CheckEnvVars
     . "/tmp/SLACK_JOB_STATUS"
     ShouldPost

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -1,3 +1,5 @@
+LOG_PATH=/tmp/slack-orb/logs
+
 BuildMessageBody() {
     # Send message
     #   If sending message, default to custom template,
@@ -37,6 +39,7 @@ PostToSlack() {
             echo "The message body being sent to Slack is: $SLACK_MSG_BODY"
         fi
         SLACK_SENT_RESPONSE=$(curl -s -f -X POST -H 'Content-type: application/json' -H "Authorization: Bearer $SLACK_ACCESS_TOKEN" --data "$SLACK_MSG_BODY" https://slack.com/api/chat.postMessage)
+        echo SLACK_SENT_RESPONSE > $LOG_PATH/SLACK_SENT_RESPONSE_LOG.txt
         if [ -n "${SLACK_PARAM_DEBUG:-}" ]; then
             echo "The response from the API call to slack is : $SLACK_SENT_RESPONSE"
         fi        
@@ -150,6 +153,7 @@ ShouldPost() {
 # This is done so this script may be tested.
 ORB_TEST_ENV="bats-core"
 if [ "${0#*$ORB_TEST_ENV}" = "$0" ]; then
+    mkdir -p LOG_PATH
     CheckEnvVars
     . "/tmp/SLACK_JOB_STATUS"
     ShouldPost

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -1,4 +1,4 @@
-if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
+if [ $EUID = 0 ]; then export SUDO=""; else export SUDO="sudo"; fi
 
 LOG_PATH=/tmp/slack-orb/logs
 

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -1,6 +1,4 @@
-# shellcheck disable=SC2001
-if [ $EUID = 0 ]; then export SUDO=""; else export SUDO="sudo"; fi
-
+if [ "$(id -u)" = 0 ]; then export SUDO=""; else export SUDO="sudo"; fi
 LOG_PATH=/tmp/slack-orb/logs
 
 BuildMessageBody() {

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2001
 if [ $EUID = 0 ]; then export SUDO=""; else export SUDO="sudo"; fi
 
 LOG_PATH=/tmp/slack-orb/logs

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -40,6 +40,7 @@ PostToSlack() {
             echo "The message body being sent to Slack is: $SLACK_MSG_BODY"
         fi
         SLACK_SENT_RESPONSE=$(curl -s -f -X POST -H 'Content-type: application/json' -H "Authorization: Bearer $SLACK_ACCESS_TOKEN" --data "$SLACK_MSG_BODY" https://slack.com/api/chat.postMessage)
+        $SUDO mkdir -p $LOG_PATH
         echo SLACK_SENT_RESPONSE > $LOG_PATH/SLACK_SENT_RESPONSE_LOG.txt
         if [ -n "${SLACK_PARAM_DEBUG:-}" ]; then
             echo "The response from the API call to slack is : $SLACK_SENT_RESPONSE"
@@ -152,7 +153,7 @@ ShouldPost() {
 
 PrepareEnvinronment() {
     if [ -L "$LOG_PATH" ]; then
-        $SUDO mkdir -p LOG_PATH
+        $SUDO mkdir -p $LOG_PATH
     fi
 }
 


### PR DESCRIPTION
Closes #256 by appending the notification message body and response to `/tmp/slack-orb/logs/post-to-slack.json` for every `slack/notify` step. Example:

Given:
```
      ...
      - slack/notify:
          template: basic_fail_1
          mentions: "@orbs"
          event: always
      ...
```

`/tmp/slack-orb/logs/post-to-slack.json` will contain:
```
[
  {
    "slackMessageBody": {
      "text": "CircleCI job failed.",
      "blocks": [...],
      "channel": "potato"
    },
    "slackSentResponse": {
      "ok": true,
      "channel": "potato",
      "ts": "1642183316.024400",
      "message": {
        "type": "message",
        "subtype": "bot_message",
        "text": "CircleCI job failed.",
        "ts": "1642183316.024400",
        "username": "ThePotatoMaster",
        "bot_id": "bot_id",
        "blocks": [...]
      },
      "warning": "missing_charset",
      "response_metadata": {
        "warnings": [
          "missing_charset"
        ]
      }
    }
  }
]
```