### PR TITLE
Update notify.sh to add a option to override SUDO variable [semver:patch]

### DIFF
--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 if ! which sudo > /dev/null 2>&1 || [ "$(id -u)" = 0 ]; then
-    SUDO="${SUDO:-''}";
+    SUDO=${SUDO:-""};
 else
-    SUDO="${SUDO:-sudo}";
+    SUDO=${SUDO:-sudo};
 fi
 
 LOG_PATH=/tmp/slack-orb/logs

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-if ! which sudo > /dev/null 2>&1 || [ "$(id -u)" = 0 ] ; then export SUDO=""; else export SUDO="sudo"; fi
+if ! which sudo > /dev/null 2>&1 || [ "$(id -u)" = 0 ]; then
+    SUDO="${SUDO:-''}";
+else
+    SUDO="${SUDO:-sudo}";
+fi
+
 LOG_PATH=/tmp/slack-orb/logs
 POST_TO_SLACK_LOG=post-to-slack.json
 
@@ -45,7 +50,7 @@ PostToSlack() {
             '. += [{"slackMessageBody": $message, "slackSentResponse": $response}]' | $SUDO tee $LOG_PATH/$POST_TO_SLACK_LOG
         if [ -n "${SLACK_PARAM_DEBUG:-}" ]; then
             echo "The response from the API call to slack is : $SLACK_SENT_RESPONSE"
-        fi        
+        fi
         SLACK_ERROR_MSG=$(echo "$SLACK_SENT_RESPONSE" | jq '.error')
         if [ ! "$SLACK_ERROR_MSG" = "null" ]; then
             echo "Slack API returned an error message:"


### PR DESCRIPTION
We've been using the slack orb in our team repository, and noticed an issue that the notify script failed with `sudo: no password was provided` error. This is because, the root user has configured the password. 

Build URL: https://app.circleci.com/pipelines/github/circleci/mongo-config-management/3287/workflows/3be9fc63-2298-4d9c-82ff-3a5418851a25/jobs/5206

We want to avoid using `sudo` on the runner executor, so I've changed the notify script to override the SUDO variable by the environment variable. Also, added some small fixes.

## Changes
- remove `export`. There is no reason to use export here. In shell script, a variable is in the global scope as default.
- override SUDO if there is a `SUDO` environment variable
- remove unnecessary spaces