### PR TITLE
[semver:minor] Add skip functionality to slack

### DIFF
--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -19,9 +19,9 @@ parameters:
     default: ""
   event:
     description: |
-      In what event should this message send? Options: ["fail", "pass", "always"]
+      In what event should this message send? Options: ["fail", "pass", "skip", "always"]
     type: enum
-    enum: ["fail", "pass", "always"]
+    enum: ["fail", "pass", "skip", "always"]
     default: "always"
   branch_pattern:
     description: |
@@ -59,15 +59,10 @@ parameters:
       default: false
 steps:
   - run:
-      when: on_fail
-      name: Slack - Detecting Job Status (FAIL)
+      when: always
+      name: Slack - Detecting Job Status
       command: |
-        echo 'export CCI_STATUS="fail"' > /tmp/SLACK_JOB_STATUS
-  - run:
-      when: on_success
-      name: Slack - Detecting Job Status (PASS)
-      command: |
-        echo 'export CCI_STATUS="pass"' > /tmp/SLACK_JOB_STATUS
+        echo 'export CCI_STATUS=<< parameters.event >>' > /tmp/SLACK_JOB_STATUS
   - run:
       when: always
       name: Slack - Sending Notification

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -59,10 +59,15 @@ parameters:
       default: false
 steps:
   - run:
-      when: always
-      name: Slack - Detecting Job Status
+      when: on_fail
+      name: Slack - Detecting Job Status (FAIL)
       command: |
-        echo 'export CCI_STATUS=<< parameters.event >>' > /tmp/SLACK_JOB_STATUS
+        echo 'export CCI_STATUS="fail"' > /tmp/SLACK_JOB_STATUS
+  - run:
+      when: on_success
+      name: Slack - Detecting Job Status (PASS)
+      command: |
+        echo 'export CCI_STATUS="pass"' > /tmp/SLACK_JOB_STATUS
   - run:
       when: always
       name: Slack - Sending Notification

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -132,7 +132,7 @@ CheckEnvVars() {
 }
 
 ShouldPost() {
-    if [ "$CCI_STATUS != "skip" ] && [ "$CCI_STATUS" = "$SLACK_PARAM_EVENT" || "$SLACK_PARAM_EVENT" = "always" ]; then
+    if [ "$SLACK_PARAM_EVENT" -z "skip" ] && [ "$CCI_STATUS" = "$SLACK_PARAM_EVENT" || "$SLACK_PARAM_EVENT" = "always" ]; then
         # In the event the Slack notification would be sent, first ensure it is allowed to trigger
         # on this branch or this tag.
         FilterBy "$SLACK_PARAM_BRANCHPATTERN" "${CIRCLE_BRANCH:-}"

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -132,7 +132,7 @@ CheckEnvVars() {
 }
 
 ShouldPost() {
-    if [ "$CCI_STATUS" = "$SLACK_PARAM_EVENT" ] || [ "$SLACK_PARAM_EVENT" = "always" ]; then
+    if [ "$CCI_STATUS != "skip" ] && [ "$CCI_STATUS" = "$SLACK_PARAM_EVENT" || "$SLACK_PARAM_EVENT" = "always" ]; then
         # In the event the Slack notification would be sent, first ensure it is allowed to trigger
         # on this branch or this tag.
         FilterBy "$SLACK_PARAM_BRANCHPATTERN" "${CIRCLE_BRANCH:-}"

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -132,7 +132,7 @@ CheckEnvVars() {
 }
 
 ShouldPost() {
-    if [ "$SLACK_PARAM_EVENT" -z "skip" ] && [ "$CCI_STATUS" = "$SLACK_PARAM_EVENT" || "$SLACK_PARAM_EVENT" = "always" ]; then
+    if [ "$SLACK_PARAM_EVENT" != "skip" ] && [ "$CCI_STATUS" = "$SLACK_PARAM_EVENT" || "$SLACK_PARAM_EVENT" = "always" ]; then
         # In the event the Slack notification would be sent, first ensure it is allowed to trigger
         # on this branch or this tag.
         FilterBy "$SLACK_PARAM_BRANCHPATTERN" "${CIRCLE_BRANCH:-}"

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -139,6 +139,8 @@ ShouldPost() {
         FilterBy "$SLACK_PARAM_TAGPATTERN" "${CIRCLE_TAG:-}"
 
         echo "Posting Status"
+    elif [ "$SLACK_PARAM_EVENT" = "skip" ]; then
+        echo "This command is set to skip, not posting to slack"
     else
         # dont send message.
         echo "NO SLACK ALERT"


### PR DESCRIPTION
### SEMVER Update Type: 
Minor 

### Description: 
Add a "skip" option
### Motivation: 
We have a need to dynamically set whether or not the slack orb runs that would be picked during the run (so parameters would not work in this use case). This pull request adds a "skip" option, so we can then set "event" to be something we can pick during the CI run. 
### Closes Issues: 
None 

ISSUE URL
Checklist:
 All new jobs, commands, executors, parameters have descriptions.
No new commands added
 Usage Example version numbers have been updated. 
I don't think that was needed for this PR, but could be wrong?
 Changelog has been updated.
I didn't see a changelog in this repository. Am i missing something? 