### PR TITLE
Restrict logs creation to when the debug flag is set to true [semver:patch]

### DIFF
--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -59,7 +59,7 @@ parameters:
       description: |
        View payload and response being sent to Slack API.
        Enable to view full payload being sent to Slack and response being received from the API call.
-       Unredacted content can be viewed by re-running the job with SSH and accessing the content of the log files referenced in the job output.
+       Redacted content can be viewed by re-running the job with SSH and accessing the log files referenced in the job output.
       type: boolean
       default: false
 steps:

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -57,8 +57,9 @@ parameters:
       default: true
   debug:
       description: |
-       View payload and response being sent to slack api.
-       Enable to view full payload being sent to slack and response being recieved from the API call.
+       View payload and response being sent to Slack API.
+       Enable to view full payload being sent to Slack and response being received from the API call.
+       Unredacted content can be viewed by re-running the job with SSH and accessing the content of the log files referenced in the job output.
       type: boolean
       default: false
 steps:

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -57,7 +57,7 @@ parameters:
       default: true
   debug:
       description: |
-       View payload and response being sent to Slack API.
+       View payload and response being sent to the Slack API.
        Enable to view full payload being sent to Slack and response being received from the API call.
        Redacted content can be viewed by re-running the job with SSH and accessing the log files referenced in the job output.
       type: boolean

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -57,9 +57,9 @@ parameters:
       default: true
   debug:
       description: |
-       View payload and response being sent to the Slack API.
        Enable to view full payload being sent to Slack and response being received from the API call.
        Redacted content can be viewed by re-running the job with SSH and accessing the log files referenced in the job output.
+       When run in a persistent build environment such as CircleCI Runner, these debug log files may remain in the system's temporary filesystem indefinitely and accumulate over time.
       type: boolean
       default: false
 steps:

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -45,8 +45,8 @@ PostToSlack() {
             echo "The message body being sent to Slack is: $SLACK_MSG_BODY"
         fi
         SLACK_SENT_RESPONSE=$(curl -s -f -X POST -H 'Content-type: application/json' -H "Authorization: Bearer $SLACK_ACCESS_TOKEN" --data "$SLACK_MSG_BODY" https://slack.com/api/chat.postMessage)
-        cat $LOG_PATH/$POST_TO_SLACK_LOG | jq --argjson message "$SLACK_MSG_BODY"  --argjson response "$SLACK_SENT_RESPONSE" \
-            '. += [{"slackMessageBody": $message, "slackSentResponse": $response}]' | tee $LOG_PATH/$POST_TO_SLACK_LOG
+        cat "$LOG_PATH"/"$POST_TO_SLACK_LOG" | jq --argjson message "$SLACK_MSG_BODY"  --argjson response "$SLACK_SENT_RESPONSE" \
+            '. += [{"slackMessageBody": $message, "slackSentResponse": $response}]' | tee "$LOG_PATH"/"$POST_TO_SLACK_LOG"
         if [ -n "${SLACK_PARAM_DEBUG:-}" ]; then
             echo "The response from the API call to slack is : $SLACK_SENT_RESPONSE"
         fi
@@ -78,8 +78,8 @@ InstallJq() {
     echo "Checking For JQ + CURL"
     if command -v curl >/dev/null 2>&1 && ! command -v jq >/dev/null 2>&1; then
         uname -a | grep Darwin > /dev/null 2>&1 && JQ_VERSION=jq-osx-amd64 || JQ_VERSION=jq-linux32
-        curl -Ls -o $JQ_PATH https://github.com/stedolan/jq/releases/download/jq-1.6/${JQ_VERSION}
-        chmod +x $JQ_PATH
+        curl -Ls -o "$JQ_PATH" https://github.com/stedolan/jq/releases/download/jq-1.6/"${JQ_VERSION}"
+        chmod +x "$JQ_PATH"
         command -v jq >/dev/null 2>&1
         return $?
     else
@@ -161,8 +161,8 @@ ShouldPost() {
 }
 
 SetupLogs() {
-    if [ ! -f "$LOG_PATH/$POST_TO_SLACK_LOG" ]; then
-        echo "[]" | tee $LOG_PATH/$POST_TO_SLACK_LOG
+    if [ ! -f "$LOG_PATH"/"$POST_TO_SLACK_LOG" ]; then
+        echo "[]" | tee "$LOG_PATH"/"$POST_TO_SLACK_LOG"
     fi
 }
 

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -40,14 +40,14 @@ PostToSlack() {
         echo "Sending to Slack Channel: $i"
         SLACK_MSG_BODY=$(echo "$SLACK_MSG_BODY" | jq --arg channel "$i" '.channel = $channel')
         if [ -n "${SLACK_PARAM_DEBUG:-}" ]; then
-            printf "%s" "$SLACK_MSG_BODY" > "$SLACK_MSG_BODY_LOG"
+            printf "%s\n" "$SLACK_MSG_BODY" > "$SLACK_MSG_BODY_LOG"
             echo "The message body being sent to Slack can be found below. To view redacted values, rerun the job with SSH and access: ${SLACK_MSG_BODY_LOG}"
             echo "$SLACK_MSG_BODY"
         fi
         SLACK_SENT_RESPONSE=$(curl -s -f -X POST -H 'Content-type: application/json' -H "Authorization: Bearer $SLACK_ACCESS_TOKEN" --data "$SLACK_MSG_BODY" https://slack.com/api/chat.postMessage)
         
         if [ -n "${SLACK_PARAM_DEBUG:-}" ]; then
-            printf "%s" "$SLACK_SENT_RESPONSE" > "$SLACK_SENT_RESPONSE_LOG"
+            printf "%s\n" "$SLACK_SENT_RESPONSE" > "$SLACK_SENT_RESPONSE_LOG"
             echo "The response from the API call to Slack can be found below. To view redacted values, rerun the job with SSH and access: ${SLACK_SENT_RESPONSE_LOG}"
             echo "$SLACK_SENT_RESPONSE"
         fi
@@ -169,9 +169,9 @@ SetupLogs() {
         SLACK_SENT_RESPONSE_LOG="$LOG_PATH/response.json"
 
         touch "$SLACK_MSG_BODY_LOG"
-        touch "$SLACK_SENT_RESPONSE_LOG"
-        
         chmod 0600 "$SLACK_MSG_BODY_LOG"
+
+        touch "$SLACK_SENT_RESPONSE_LOG"        
         chmod 0600 "$SLACK_SENT_RESPONSE_LOG"
     fi
 }

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -41,14 +41,14 @@ PostToSlack() {
         SLACK_MSG_BODY=$(echo "$SLACK_MSG_BODY" | jq --arg channel "$i" '.channel = $channel')
         if [ -n "${SLACK_PARAM_DEBUG:-}" ]; then
             printf "%s" "$SLACK_MSG_BODY" > "$SLACK_MSG_BODY_LOG"
-            echo "The message body being sent to Slack can be found below. To view unredacted values, rerun the job with SSH and access: ${SLACK_MSG_BODY_LOG}"
+            echo "The message body being sent to Slack can be found below. To view redacted values, rerun the job with SSH and access: ${SLACK_MSG_BODY_LOG}"
             echo "$SLACK_MSG_BODY"
         fi
         SLACK_SENT_RESPONSE=$(curl -s -f -X POST -H 'Content-type: application/json' -H "Authorization: Bearer $SLACK_ACCESS_TOKEN" --data "$SLACK_MSG_BODY" https://slack.com/api/chat.postMessage)
         
         if [ -n "${SLACK_PARAM_DEBUG:-}" ]; then
             printf "%s" "$SLACK_SENT_RESPONSE" > "$SLACK_SENT_RESPONSE_LOG"
-            echo "The response from the API call to Slack can be found below. To view unredacted values, rerun the job with SSH and access: ${SLACK_SENT_RESPONSE_LOG}"
+            echo "The response from the API call to Slack can be found below. To view redacted values, rerun the job with SSH and access: ${SLACK_SENT_RESPONSE_LOG}"
             echo "$SLACK_SENT_RESPONSE"
         fi
 

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -41,14 +41,14 @@ PostToSlack() {
         SLACK_MSG_BODY=$(echo "$SLACK_MSG_BODY" | jq --arg channel "$i" '.channel = $channel')
         if [ -n "${SLACK_PARAM_DEBUG:-}" ]; then
             printf "%s" "$SLACK_MSG_BODY" > "$SLACK_MSG_BODY_LOG"
-            echo "The message body being sent to Slack can be found below. To view masked values, rerun the job with SSH and go to ${SLACK_MSG_BODY_LOG}"
+            echo "The message body being sent to Slack can be found below. To view unredacted values, rerun the job with SSH and access: ${SLACK_MSG_BODY_LOG}"
             echo "$SLACK_MSG_BODY"
         fi
         SLACK_SENT_RESPONSE=$(curl -s -f -X POST -H 'Content-type: application/json' -H "Authorization: Bearer $SLACK_ACCESS_TOKEN" --data "$SLACK_MSG_BODY" https://slack.com/api/chat.postMessage)
         
         if [ -n "${SLACK_PARAM_DEBUG:-}" ]; then
             printf "%s" "$SLACK_SENT_RESPONSE" > "$SLACK_SENT_RESPONSE_LOG"
-            echo "The response from the API call to Slack can be found below. To view masked values, rerun the job with SSH and go to ${SLACK_SENT_RESPONSE_LOG}"
+            echo "The response from the API call to Slack can be found below. To view unredacted values, rerun the job with SSH and access: ${SLACK_SENT_RESPONSE_LOG}"
             echo "$SLACK_SENT_RESPONSE"
         fi
 

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -168,11 +168,8 @@ SetupLogs() {
         SLACK_MSG_BODY_LOG="$LOG_PATH/payload.json"
         SLACK_SENT_RESPONSE_LOG="$LOG_PATH/response.json"
 
-        touch "$SLACK_MSG_BODY_LOG"
-        chmod 0600 "$SLACK_MSG_BODY_LOG"
-
-        touch "$SLACK_SENT_RESPONSE_LOG"        
-        chmod 0600 "$SLACK_SENT_RESPONSE_LOG"
+        touch "$SLACK_MSG_BODY_LOG" "$SLACK_SENT_RESPONSE_LOG"
+        chmod 0600 "$SLACK_MSG_BODY_LOG" "$SLACK_SENT_RESPONSE_LOG"
     fi
 }
 


### PR DESCRIPTION
With this change, the `notify` command will only save the request payload and response if the `debug` parameter is set to `true`.

This PR also modifies how we handle log creation. Before, we were appending new entries to a single log file. Now we are keeping them more concise and simple to handle by splitting requests and payload into different files and generating new directories for each `slack/notify` command. 