### PR TITLE
feat: add circleci_host param option

### DIFF
--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -62,6 +62,11 @@ parameters:
        When run in a persistent build environment such as CircleCI Runner, these debug log files may remain in the system's temporary filesystem indefinitely and accumulate over time.
       type: boolean
       default: false
+  circleci_host:
+      description: |
+       A CircleCI Host which used in a message template.
+      type: string
+      default: https://circleci.com
 steps:
   - run:
       when: on_fail
@@ -86,6 +91,7 @@ steps:
         SLACK_PARAM_CHANNEL: "<<parameters.channel>>"
         SLACK_PARAM_IGNORE_ERRORS: "<<parameters.ignore_errors>>"
         SLACK_PARAM_DEBUG: "<<parameters.debug>>"
+        SLACK_PARAM_CIRCLECI_HOST: "<<parameters.circleci_host>>"
         # import pre-built templates using the orb-pack local script include.
         basic_fail_1: "<<include(message_templates/basic_fail_1.json)>>"
         success_tagged_deploy_1: "<<include(message_templates/success_tagged_deploy_1.json)>>"

--- a/src/message_templates/basic_on_hold_1.json
+++ b/src/message_templates/basic_on_hold_1.json
@@ -49,7 +49,7 @@
 						"type": "plain_text",
 						"text": "View Workflow"
 					},
-					"url": "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
+					"url": "${SLACK_PARAM_CIRCLECI_HOST}/workflow-run/${CIRCLE_WORKFLOW_ID}"
 				}
 			]
 		}


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] README has been updated, if necessary

### Motivation, issues

Hi, there.

I'm using CircleCI through CircleCI Server in my company. The `basic_on_hold_1.json` message template has hardcoded the CircleCI host. I've added an optional parameter that enables change it. Thank you.

### Description

1. add `circleci_host` optional parameter to `notify.yml` command
1. use it in `notify.sh` -> `basic_on_hold_1.json` template
