### PR TITLE
fix: check branch pattern before env vars

### DIFF
--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -177,11 +177,11 @@ SetupLogs() {
 # This is done so this script may be tested.
 ORB_TEST_ENV="bats-core"
 if [ "${0#*"$ORB_TEST_ENV"}" = "$0" ]; then
+    . "/tmp/SLACK_JOB_STATUS"
+    ShouldPost
     SetupEnvVars
     SetupLogs
     CheckEnvVars
-    . "/tmp/SLACK_JOB_STATUS"
-    ShouldPost
     InstallJq
     BuildMessageBody
     PostToSlack


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

By having the branch filtering before environment variables check, the users won't have the job failing when they don't mean to execute it in the first place.

Closes #252.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

This PR changes the order of function execution in the orb. The `ShouldPost` will be the first function to execute, and if it matches non-execution pattern, it will prevent jobs from failing because of unset environment variables.