### PR TITLE
feat: add match inversion for branch and tag patterns

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -77,6 +77,10 @@ jobs:
           event: always
           template: MY_ORB_TEMPLATE
       - slack/notify
+      # Should run for every branch but master
+      - slack/notify:
+          branch_pattern: "master"
+          invert_match: true
 
 workflows:
   test-deploy:

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -37,6 +37,12 @@ parameters:
       A comma separated list of regex matchable tag names. Notifications will only be sent if sent from a job from these branches. By default ".+" will be used to match all tags. Pattern must match the full string, no partial matches.
     type: string
     default: ".+"
+  invert_match:
+    description: |
+      Invert the branch and tag patterns.
+      If set to true, notifications will only be sent if sent from a job from branches and tags that do not match the patterns.
+    type: boolean
+    default: false
   mentions:
     description: |
       Exports to the "$SLACK_PARAM_MENTIONS" environment variable for use in templates.
@@ -88,6 +94,7 @@ steps:
         SLACK_PARAM_MENTIONS: "<<parameters.mentions>>"
         SLACK_PARAM_BRANCHPATTERN: "<<parameters.branch_pattern>>"
         SLACK_PARAM_TAGPATTERN: "<<parameters.tag_pattern>>"
+        SLACK_PARAM_INVERT_MATCH: "<<parameters.invert_match>>"
         SLACK_PARAM_CHANNEL: "<<parameters.channel>>"
         SLACK_PARAM_IGNORE_ERRORS: "<<parameters.ignore_errors>>"
         SLACK_PARAM_DEBUG: "<<parameters.debug>>"

--- a/src/jobs/on-hold.yml
+++ b/src/jobs/on-hold.yml
@@ -7,6 +7,12 @@ parameters:
       A comma separated list of regex matchable branch names. Notifications will only be sent if sent from a job from these branches. By default ".+" will be used to match all branches. Pattern must match the full string, no partial matches.
     type: string
     default: ".+"
+  invert_match:
+    description: |
+      Invert the branch and tag patterns.
+      If set to true, notifications will only be sent if sent from a job from branches and tags that do not match the patterns.
+    type: boolean
+    default: false
   mentions:
     description: |
       Exports to the "$SLACK_PARAM_MENTIONS" environment variable for use in templates.
@@ -53,6 +59,7 @@ steps:
       event: always
       template: <<parameters.template>>
       branch_pattern: <<parameters.branch_pattern>>
+      invert_match: <<parameters.invert_match>>
       custom: <<parameters.custom>>
       mentions: <<parameters.mentions>>
       channel: <<parameters.channel>>

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -96,11 +96,17 @@ FilterBy() {
       return
     fi
 
+    # Add the "invert-match" flag to grep if it is set.
+    INVERT_MATCH=""
+    if [ "$SLACK_PARAM_INVERT_MATCH" -eq 1 ]; then
+        INVERT_MATCH="--invert-match"
+    fi
+
     # If any pattern supplied matches the current branch or the current tag, proceed; otherwise, exit with message.
+    # However, if the invert_match parameter is set, invert the match.
     FLAG_MATCHES_FILTER="false"
-    for i in $(echo "$1" | sed "s/,/ /g")
-    do
-        if echo "$2" | grep -Eq "^${i}$"; then
+    for i in $(echo "$1" | sed "s/,/ /g"); do
+        if echo "$2" | grep -Eq ${INVERT_MATCH:+"$INVERT_MATCH"} "^${i}$"; then
             FLAG_MATCHES_FILTER="true"
             break
         fi


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Closes #269.

### Description

This PR adds a new `invert-match` parameter to the `notify` command. If set to true, the parameter includes the `--invert-match` or `-v` flag in grep.