### PR TITLE
Fix invert_match to work with multiple branch patterns

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ workflows:
           requires:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           # Use a context to hold your publishing token.
-          context: orb-publishing
+          context: orb-publisher
           filters:
             tags:
               only: /.*/

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -114,7 +114,7 @@ workflows:
             - orb-tools/review
             - orb-tools/pack
             - integration-test-templates
-          context: orb-publishing
+          context: orb-publisher
           filters:
             branches:
               ignore: /.*/

--- a/src/jobs/on-hold.yml
+++ b/src/jobs/on-hold.yml
@@ -41,7 +41,7 @@ parameters:
   debug:
       description: |
        View payload and response being sent to slack api.
-       Enable to view full payload being sent to slack and response being recieved from the API call.
+       Enable to view full payload being sent to slack and response being received from the API call.
       type: boolean
       default: false
   circleci_host:

--- a/src/tests/notify.bats
+++ b/src/tests/notify.bats
@@ -104,3 +104,21 @@ setup() {
     echo "Error output debug: $output"
     [ "$status" -eq 0 ] # In any case, this should return a 0 exit as to not block a build/deployment.
 }
+
+@test "13: FilterBy - match and SLACK_PARAM_INVERT_MATCH is set" {
+    CIRCLE_BRANCH="pr-123"
+    SLACK_PARAM_INVERT_MATCH="1"
+    run FilterBy "$SLACK_PARAM_BRANCHPATTERN" "$CIRCLE_BRANCH"
+    echo "Error output debug: $output"
+    [ "$output" == "NO SLACK ALERT" ] # "pr-[0-9]+" should match but inverted: Error message expected.
+    [ "$status" -eq 0 ] # In any case, this should return a 0 exit as to not block a build/deployment.
+}
+
+@test "14: FilterBy - non-match and SLACK_PARAM_INVERT_MATCH is set" {
+    CIRCLE_BRANCH="foo"
+    SLACK_PARAM_INVERT_MATCH="1"
+    run FilterBy "$SLACK_PARAM_BRANCHPATTERN" "$CIRCLE_BRANCH"
+    echo "Error output debug: $output"
+    [ "$output" == "" ] # Nothing should match but inverted: No output error
+    [ "$status" -eq 0 ] # In any case, this should return a 0 exit as to not block a build/deployment.
+}


### PR DESCRIPTION
First off - thanks for adding the `invert_match` param in the last release. This makes dealing with notifications for unknown branch names much easier. Unfortunately, in its current state it only works if you have a single pattern in the `branch_pattern` pattern. This is due to the "match fast" logic with the `break` when a match occurs. When inverting this logic, we need to ensure that ALL of the patterns don't match instead of ANY.

Example:
```yaml
branch_pattern: 'foo,bar,baz'
invert_match: true
```
If we're currently deploying the "baz" branch, "foo" does not match, so with `invert_match` true, `FLAG_MATCHES_FILTER` gets set to true, the `for`-loop is exited and the slack notification is incorrectly sent.

This PR simplifies the logic by only taking into account whether or not `invert_match` is true and then negates the `FLAG_MATCHES_FILTER` behavior when deciding whether or not to exit.
