### PR TITLE
fix: invert match conditionals and bats tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ setup: true
 orbs:
   orb-tools: circleci/orb-tools@11.4
   shellcheck: circleci/shellcheck@3.1
+  bats: circleci/bats@1.0
 
 workflows:
   lint-pack:
@@ -24,11 +25,16 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - bats/run:
+          path: ./src/tests
+          filters:
+            tags:
+              only: /.*/
       - orb-tools/publish:
           orb-name: circleci/slack
           vcs-type: << pipeline.project.type >>
           requires:
-            [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
+            [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check, bats/run]
           # Use a context to hold your publishing token.
           context: orb-publisher
           filters:

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -92,7 +92,6 @@ InstallJq() {
 }
 
 FilterBy() {
-    set -x
     if [ -z "$1" ] || [ -z "$2" ]; then
       return
     fi
@@ -106,8 +105,8 @@ FilterBy() {
         fi
     done
     # If the invert_match parameter is set, invert the match.
-    if [ "$FLAG_MATCHES_FILTER" = "false" ] && [ "$SLACK_PARAM_INVERT_MATCH" -eq 0 ] ||
-       [ "$FLAG_MATCHES_FILTER" = "true" ] && [ "$SLACK_PARAM_INVERT_MATCH" -eq 1 ]
+    if { [ "$FLAG_MATCHES_FILTER" = "false" ] && [ "$SLACK_PARAM_INVERT_MATCH" -eq 0 ]; } || \
+        { [ "$FLAG_MATCHES_FILTER" = "true" ] && [ "$SLACK_PARAM_INVERT_MATCH" -eq 1 ]; }
     then
         # dont send message.
         echo "NO SLACK ALERT"
@@ -116,7 +115,6 @@ FilterBy() {
         echo "Current matching pattern: $1"
         exit 0
     fi
-    set +x
 }
 
 SetupEnvVars() {

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -92,6 +92,7 @@ InstallJq() {
 }
 
 FilterBy() {
+    set -x
     if [ -z "$1" ] || [ -z "$2" ]; then
       return
     fi
@@ -115,6 +116,7 @@ FilterBy() {
         echo "Current matching pattern: $1"
         exit 0
     fi
+    set +x
 }
 
 SetupEnvVars() {

--- a/src/tests/notify.bats
+++ b/src/tests/notify.bats
@@ -50,6 +50,7 @@ setup() {
 }
 
 @test "6: FilterBy - match-all default" {
+    SLACK_PARAM_INVERT_MATCH="0"
     SLACK_PARAM_BRANCHPATTERN=".+"
     CIRCLE_BRANCH="xyz-123"
     run FilterBy "$SLACK_PARAM_BRANCHPATTERN" "$CIRCLE_BRANCH"
@@ -60,6 +61,7 @@ setup() {
 }
 
 @test "7: FilterBy - string" {
+    SLACK_PARAM_INVERT_MATCH="0"
     CIRCLE_BRANCH="master"
     run FilterBy "$SLACK_PARAM_BRANCHPATTERN" "$CIRCLE_BRANCH"
     echo "Error output debug: $output"
@@ -68,6 +70,7 @@ setup() {
 }
 
 @test "8: FilterBy - regex numbers" {
+    SLACK_PARAM_INVERT_MATCH="0"
     CIRCLE_BRANCH="pr-123"
     run FilterBy "$SLACK_PARAM_BRANCHPATTERN" "$CIRCLE_BRANCH"
     echo "Error output debug: $output"
@@ -76,6 +79,7 @@ setup() {
 }
 
 @test "9: FilterBy - non-match" {
+    SLACK_PARAM_INVERT_MATCH="0"
     CIRCLE_BRANCH="x"
     run FilterBy "$SLACK_PARAM_BRANCHPATTERN" "$CIRCLE_BRANCH"
     echo "Error output debug: $output"
@@ -84,6 +88,7 @@ setup() {
 }
 
 @test "10: FilterBy - no partial-match" {
+    SLACK_PARAM_INVERT_MATCH="0"
     CIRCLE_BRANCH="pr-"
     run FilterBy "$SLACK_PARAM_BRANCHPATTERN" "$CIRCLE_BRANCH"
     echo "Error output debug: $output"
@@ -92,6 +97,7 @@ setup() {
 }
 
 @test "11: FilterBy - SLACK_PARAM_BRANCHPATTERN is empty" {
+    SLACK_PARAM_INVERT_MATCH="0"
     unset SLACK_PARAM_BRANCHPATTERN
     CIRCLE_BRANCH="master"
     run FilterBy "$SLACK_PARAM_BRANCHPATTERN" "$CIRCLE_BRANCH"
@@ -100,6 +106,7 @@ setup() {
 }
 
 @test "12: FilterBy - CIRCLE_BRANCH is empty" {
+    SLACK_PARAM_INVERT_MATCH="0"
     run FilterBy "$SLACK_PARAM_BRANCHPATTERN" "$CIRCLE_BRANCH"
     echo "Error output debug: $output"
     [ "$status" -eq 0 ] # In any case, this should return a 0 exit as to not block a build/deployment.

--- a/src/tests/notify.bats
+++ b/src/tests/notify.bats
@@ -1,6 +1,7 @@
 setup() {
     source ./src/scripts/notify.sh
     export SLACK_PARAM_BRANCHPATTERN=$(cat $BATS_TEST_DIRNAME/sampleBranchFilters.txt)
+    SLACK_PARAM_INVERT_MATCH="0"
 }
 
 @test "1: Skip message on no event" {
@@ -50,7 +51,6 @@ setup() {
 }
 
 @test "6: FilterBy - match-all default" {
-    SLACK_PARAM_INVERT_MATCH="0"
     SLACK_PARAM_BRANCHPATTERN=".+"
     CIRCLE_BRANCH="xyz-123"
     run FilterBy "$SLACK_PARAM_BRANCHPATTERN" "$CIRCLE_BRANCH"
@@ -61,7 +61,6 @@ setup() {
 }
 
 @test "7: FilterBy - string" {
-    SLACK_PARAM_INVERT_MATCH="0"
     CIRCLE_BRANCH="master"
     run FilterBy "$SLACK_PARAM_BRANCHPATTERN" "$CIRCLE_BRANCH"
     echo "Error output debug: $output"
@@ -70,7 +69,6 @@ setup() {
 }
 
 @test "8: FilterBy - regex numbers" {
-    SLACK_PARAM_INVERT_MATCH="0"
     CIRCLE_BRANCH="pr-123"
     run FilterBy "$SLACK_PARAM_BRANCHPATTERN" "$CIRCLE_BRANCH"
     echo "Error output debug: $output"
@@ -79,7 +77,6 @@ setup() {
 }
 
 @test "9: FilterBy - non-match" {
-    SLACK_PARAM_INVERT_MATCH="0"
     CIRCLE_BRANCH="x"
     run FilterBy "$SLACK_PARAM_BRANCHPATTERN" "$CIRCLE_BRANCH"
     echo "Error output debug: $output"
@@ -88,7 +85,6 @@ setup() {
 }
 
 @test "10: FilterBy - no partial-match" {
-    SLACK_PARAM_INVERT_MATCH="0"
     CIRCLE_BRANCH="pr-"
     run FilterBy "$SLACK_PARAM_BRANCHPATTERN" "$CIRCLE_BRANCH"
     echo "Error output debug: $output"
@@ -97,7 +93,6 @@ setup() {
 }
 
 @test "11: FilterBy - SLACK_PARAM_BRANCHPATTERN is empty" {
-    SLACK_PARAM_INVERT_MATCH="0"
     unset SLACK_PARAM_BRANCHPATTERN
     CIRCLE_BRANCH="master"
     run FilterBy "$SLACK_PARAM_BRANCHPATTERN" "$CIRCLE_BRANCH"
@@ -106,7 +101,6 @@ setup() {
 }
 
 @test "12: FilterBy - CIRCLE_BRANCH is empty" {
-    SLACK_PARAM_INVERT_MATCH="0"
     run FilterBy "$SLACK_PARAM_BRANCHPATTERN" "$CIRCLE_BRANCH"
     echo "Error output debug: $output"
     [ "$status" -eq 0 ] # In any case, this should return a 0 exit as to not block a build/deployment.
@@ -117,7 +111,7 @@ setup() {
     SLACK_PARAM_INVERT_MATCH="1"
     run FilterBy "$SLACK_PARAM_BRANCHPATTERN" "$CIRCLE_BRANCH"
     echo "Error output debug: $output"
-    [ "$output" == "NO SLACK ALERT" ] # "pr-[0-9]+" should match but inverted: Error message expected.
+    [[ "$output" =~ "NO SLACK ALERT" ]] # "pr-[0-9]+" should match but inverted: Error message expected.
     [ "$status" -eq 0 ] # In any case, this should return a 0 exit as to not block a build/deployment.
 }
 


### PR DESCRIPTION
## Changes

- Group conditionals and add `\` to properly break the line.
- Add the `bats` orb to run unit tests.
- Replace `==` with `=~` in the test 13.