### PR TITLE
fix: escape new line in multiline strings

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -97,10 +97,11 @@ jobs:
           branch_pattern: "master"
           invert_match: true
       - run:
-          name: Dynamically populate the mention and export the template as an environment variable
+          name: Export variable with a multiline string
           command: |
             printf '%s\n' 'export MULTILINE_STRING=$(printf "%s\\n" "Line 1." "Line 2." "Line 3.")' >> "$BASH_ENV"
       - slack/notify:
+          step_name: "Notify with multiline string"
           event: pass
           custom: >
             {

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -86,6 +86,24 @@ jobs:
       - slack/notify:
           branch_pattern: "master"
           invert_match: true
+      - run:
+          name: Dynamically populate the mention and export the template as an environment variable
+          command: |
+            printf '%s\n' 'export MULTILINE_STRING=$(printf "%s\\n" "Line 1." "Line 2." "Line 3.")' >> "$BASH_ENV"
+      - slack/notify:
+          event: pass
+          custom: >
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "This message should show over multiple lines: $MULTILINE_STRING"
+                  }
+                }
+              ]
+            }
 
 workflows:
   test-deploy:

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -216,7 +216,7 @@ SanitizeVars() {
  
     # Replace newlines with '\\n'.
     local sanitized_value
-    sanitized_value="$(printf '%s' "$value" | awk '{printf "%s\\n", $0}')"
+    sanitized_value="$(printf '%s' "$value" | awk 'NR > 1 { printf("\\n") } { printf("%s", $0) }')"
     
     # Write the sanitized value back to the original variable.
     # shellcheck disable=SC3045 # This is working on Alpine.

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -195,17 +195,17 @@ SanitizeVars() {
   [ -z "$1" ] && { printf '%s\n' "Missing argument."; return 1; }
   local template="$1"
   
-  # Find all environment variables in the template wrapped in ${}.
+  # Find all environment variables in the template with the format $VAR or ${VAR}.
   # The "|| true" is to prevent bats from failing when no matches are found.
-  local variables_with_braces
-  variables_with_braces="$(printf '%s\n' "$template" | grep -o -E '\$\{?[a-zA-Z_0-9]*\}?' || true)"
-  [ -z "$variables_with_braces" ] && { printf '%s\n' "Nothing to sanitize."; return 0; }
-
-  # Extract the variable names from the braces.
   local variables
-  variables="$(printf '%s\n' "$variables_with_braces" | grep -o -E '[a-zA-Z0-9_]+')"
+  variables="$(printf '%s\n' "$template" | grep -o -E '\$\{?[a-zA-Z_0-9]*\}?' || true)"
+  [ -z "$variables" ] && { printf '%s\n' "Nothing to sanitize."; return 0; }
+
+  # Extract the variable names from the matches.
+  local variable_names
+  variable_names="$(printf '%s\n' "$variables" | grep -o -E '[a-zA-Z0-9_]+')"
   
-  for var in $variables; do
+  for var in $variable_names; do
     # The variable must be wrapped in double quotes before the evaluation.
     # Otherwise the newlines will be removed.
     local value

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# shellcheck disable=SC2016,SC3043
+
 JQ_PATH=/usr/local/bin/jq
 
 BuildMessageBody() {
@@ -7,10 +9,11 @@ BuildMessageBody() {
     #   if none is supplied, check for a pre-selected template value.
     #   If none, error.
     if [ -n "${SLACK_PARAM_CUSTOM:-}" ]; then
+        SanitizeVars "$SLACK_PARAM_CUSTOM" 
         ModifyCustomTemplate
         # shellcheck disable=SC2016
         CUSTOM_BODY_MODIFIED=$(echo "$CUSTOM_BODY_MODIFIED" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed 's/`/\\`/g')
-        T2=$(eval echo \""$CUSTOM_BODY_MODIFIED"\")
+        T2="$(eval printf '%s' \""$CUSTOM_BODY_MODIFIED"\")"
     else
         # shellcheck disable=SC2154
         if [ -n "${SLACK_PARAM_TEMPLATE:-}" ]; then TEMPLATE="\$$SLACK_PARAM_TEMPLATE"
@@ -20,18 +23,17 @@ BuildMessageBody() {
         fi
 
         [ -z "${SLACK_PARAM_TEMPLATE:-}" ] && echo "No message template was explicitly chosen. Based on the job status '$CCI_STATUS' the template '$TEMPLATE' will be used."
+        template_body="$(eval printf '%s' \""$TEMPLATE\"")"
+        SanitizeVars "$template_body"
 
         # shellcheck disable=SC2016
-        T1=$(eval echo "$TEMPLATE" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed 's/`/\\`/g')
-        T2=$(eval echo \""$T1"\")
+        T1="$(printf '%s' "$template_body" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed 's/`/\\`/g')"
+        T2="$(eval printf '%s' \""$T1"\")"
     fi
-
-    # Replace each newline with literal "\n": https://stackoverflow.com/a/1252191
-    message_with_escaped_newline="$(printf '%s\n' "$T2" | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/\\n/g')"
-
+   
     # Insert the default channel. THIS IS TEMPORARY
-    message_body=$(echo "$message_with_escaped_newline" | jq ". + {\"channel\": \"$SLACK_DEFAULT_CHANNEL\"}")
-    SLACK_MSG_BODY="$message_body"
+    T2="$(printf '%s' "$T2" | jq ". + {\"channel\": \"$SLACK_DEFAULT_CHANNEL\"}")"
+    SLACK_MSG_BODY="$T2"
 }
 
 PostToSlack() {
@@ -181,11 +183,47 @@ SetupLogs() {
 
 ExitIfWindows() {
     os="$(uname -s | tr '[:upper:]' '[:lower:]')"
-    if printf '%s\n' "$os" | grep --quiet 'msys*\|cygwin*' ; then
+    if printf '%s\n' "$os" | grep -q 'msys*\|cygwin*' ; then
         printf '%s\n' "Windows is not supported by this orb."
         printf '%s\n' "For more information, see: https://github.com/CircleCI-Public/slack-orb/wiki/FAQ."
         exit 1
     fi
+}
+
+# $1: Template with environment variables to be sanitized.
+SanitizeVars() {
+  [ -z "$1" ] && { printf '%s\n' "Missing argument."; return 1; }
+  local template="$1"
+  
+  # Find all environment variables in the template wrapped in ${}.
+  # The "|| true" is to prevent bats from failing when no matches are found.
+  local variables_with_braces
+  variables_with_braces="$(printf '%s\n' "$template" | grep -o -E '\$\{?[a-zA-Z_0-9]*\}?' || true)"
+  [ -z "$variables_with_braces" ] && { printf '%s\n' "Nothing to sanitize."; return 0; }
+
+  # Extract the variable names from the braces.
+  local variables
+  variables="$(printf '%s\n' "$variables_with_braces" | grep -o -E '[a-zA-Z0-9_]+')"
+  
+  for var in $variables; do
+    # The variable must be wrapped in double quotes before the evaluation.
+    # Otherwise the newlines will be removed.
+    local value
+    value="$(eval printf '%s' \"\$"$var\"")"
+    [ -z "$value" ] && { printf '%s\n' "$var is empty or doesn't exist. Skipping it..."; continue; }
+    
+    printf '%s\n' "Sanitizing $var..."
+ 
+    # Replace newlines with '\\n'.
+    local sanitized_value
+    sanitized_value="$(printf '%s' "$value" | awk '{printf "%s\\n", $0}')"
+    
+    # Write the sanitized value back to the original variable.
+    # shellcheck disable=SC3045 # This is working on Alpine.
+    printf -v "$var" "%s" "$sanitized_value"
+  done
+
+  return 0;
 }
 
 # Will not run if sourced from another script.

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -25,9 +25,13 @@ BuildMessageBody() {
         T1=$(eval echo "$TEMPLATE" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed 's/`/\\`/g')
         T2=$(eval echo \""$T1"\")
     fi
+
+    # Replace each newline with literal "\n": https://stackoverflow.com/a/1252191
+    message_with_escaped_newline="$(printf '%s\n' "$T2" | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/\\n/g')"
+
     # Insert the default channel. THIS IS TEMPORARY
-    T2=$(echo "$T2" | jq ". + {\"channel\": \"$SLACK_DEFAULT_CHANNEL\"}")
-    SLACK_MSG_BODY=$T2
+    message_body=$(echo "$message_with_escaped_newline" | jq ". + {\"channel\": \"$SLACK_DEFAULT_CHANNEL\"}")
+    SLACK_MSG_BODY="$message_body"
 }
 
 PostToSlack() {

--- a/src/tests/notify.bats
+++ b/src/tests/notify.bats
@@ -123,3 +123,10 @@ setup() {
     [ "$output" == "" ] # Nothing should match but inverted: No output error
     [ "$status" -eq 0 ] # In any case, this should return a 0 exit as to not block a build/deployment.
 }
+
+@test "15: Sanitize - Escape newlines in environment variables" {
+    CIRCLE_JOB="$(printf "%s\\n" "Line 1." "Line 2." "Line 3.")"
+    SLACK_PARAM_CUSTOM=$(cat $BATS_TEST_DIRNAME/sampleCustomTemplate.json)
+    SanitizeVars "$SLACK_PARAM_CUSTOM"
+    [ "$CIRCLE_JOB" = "Line 1.\\nLine 2.\\nLine 3." ] # Newlines should be literal and escaped
+}


### PR DESCRIPTION
## Changes

- Replace new line with literal `\n` in strings inside the template.