### PR TITLE
fix: escape backslashes

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -82,7 +82,7 @@ jobs:
       - run:
           name: Dynamically populate the mention and export the template as an environment variable
           command: |
-            echo 'export COMMIT_MESSAGE="$(git log --format=oneline -n 1 $CIRCLE_SHA1)"' >> $BASH_ENV
+            echo 'export COMMIT_MESSAGE="This text comes from an environment variable"' >> $BASH_ENV
             echo 'export SLACK_PARAM_MENTIONS="$COMMIT_MESSAGE"' >> $BASH_ENV
             echo 'export MY_ORB_TEMPLATE=$(cat src/message_templates/basic_success_1.json)' >> $BASH_ENV
       - slack/notify:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -134,6 +134,26 @@ jobs:
                 }
               ]
             }
+      - run:
+          name: Export variable with backslashes
+          command: |
+            printf '%s\n' 'export BACKSLASHES_STRING="This is how a \ looks like"' >> "$BASH_ENV"
+      - slack/notify:
+          step_name: "Notify with backslashes string"
+          event: pass
+          debug: true
+          custom: >
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "This message should show a backslash: $BACKSLASHES_STRING"
+                  }
+                }
+              ]
+            }
 
 workflows:
   test-deploy:

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -216,7 +216,7 @@ SanitizeVars() {
  
     local sanitized_value="$value"
     # Escape backslashes.
-    sanitized_value="$(printf '%s' "$sanitized_value" | awk '{gsub(/\\/, "\\\\"); print $0}')"
+    sanitized_value="$(printf '%s' "$sanitized_value" | awk '{gsub(/\\/, "&\\"); print $0}')"
     # Escape newlines.
     sanitized_value="$(printf '%s' "$sanitized_value" | awk 'NR > 1 { printf("\\n") } { printf("%s", $0) }')"
     # Escape double quotes.

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -214,11 +214,12 @@ SanitizeVars() {
     
     printf '%s\n' "Sanitizing $var..."
  
-    local sanitized_value
-
-    # Replace newlines with '\\n'.
-    sanitized_value="$(printf '%s' "$value" | awk 'NR > 1 { printf("\\n") } { printf("%s", $0) }')"
-    # Replace double quotes with '\"'.
+    local sanitized_value="$value"
+    # Escape backslashes.
+    sanitized_value="$(printf '%s' "$sanitized_value" | awk '{gsub(/\\/, "\\\\"); print $0}')"
+    # Escape newlines.
+    sanitized_value="$(printf '%s' "$sanitized_value" | awk 'NR > 1 { printf("\\n") } { printf("%s", $0) }')"
+    # Escape double quotes.
     sanitized_value="$(printf '%s' "$sanitized_value" | awk '{gsub(/\"/, "\\\""); print $0}')"
 
     # Write the sanitized value back to the original variable.

--- a/src/tests/notify.bats
+++ b/src/tests/notify.bats
@@ -1,3 +1,5 @@
+#!/usr/bin/env bats
+
 setup() {
     source ./src/scripts/notify.sh
     export SLACK_PARAM_BRANCHPATTERN=$(cat $BATS_TEST_DIRNAME/sampleBranchFilters.txt)
@@ -126,14 +128,27 @@ setup() {
 
 @test "15: Sanitize - Escape newlines in environment variables" {
     CIRCLE_JOB="$(printf "%s\\n" "Line 1." "Line 2." "Line 3.")"
+    EXPECTED="Line 1.\\nLine 2.\\nLine 3."
     SLACK_PARAM_CUSTOM=$(cat $BATS_TEST_DIRNAME/sampleCustomTemplate.json)
     SanitizeVars "$SLACK_PARAM_CUSTOM"
-    [ "$CIRCLE_JOB" = "Line 1.\\nLine 2.\\nLine 3." ] # Newlines should be literal and escaped
+    printf '%s\n' "Expected: $EXPECTED" "Actual: $CIRCLE_JOB"
+    [ "$CIRCLE_JOB" = "$EXPECTED" ] # Newlines should be literal and escaped
 }
 
 @test "16: Sanitize - Escape double quotes in environment variables" {
     CIRCLE_JOB="$(printf "%s\n" "Hello \"world\".")"
+    EXPECTED="Hello \\\"world\\\"."
     SLACK_PARAM_CUSTOM=$(cat $BATS_TEST_DIRNAME/sampleCustomTemplate.json)
     SanitizeVars "$SLACK_PARAM_CUSTOM"
-    [ "$CIRCLE_JOB" = "Hello \\\"world\\\"." ] # Double quotes should be escaped
+    printf '%s\n' "Expected: $EXPECTED" "Actual: $CIRCLE_JOB"
+    [ "$CIRCLE_JOB" = "$EXPECTED" ] # Double quotes should be escaped
+}
+
+@test "17: Sanitize - Escape backslashes in environment variables" {
+    CIRCLE_JOB="$(printf "%s\n" "removed extra '\' from  notification template")"
+    EXPECTED="removed extra '\\\' from  notification template"
+    SLACK_PARAM_CUSTOM=$(cat $BATS_TEST_DIRNAME/sampleCustomTemplate.json)
+    SanitizeVars "$SLACK_PARAM_CUSTOM"
+    printf '%s\n' "Expected: $EXPECTED" "Actual: $CIRCLE_JOB"
+    [ "$CIRCLE_JOB" = "$EXPECTED" ] # Backslashes should be escaped
 }


### PR DESCRIPTION
# Motivation

Closes #279 

# Changes

- Add backslashes to the list of characters to be sanitized in environment variables.
- Remove `git` dependency from integration tests since Alpine doesn't have it.
- Improve sanitization unit tests by adding "Expected vs Actual" output in case of failure.