### PR TITLE
fix: sanitization error with sub-shells

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -166,7 +166,30 @@ jobs:
             printf '%s\n' "Hello There!" > /tmp/msg
       - slack/notify:
           debug: true
-          step_name: "Notify with custom message coming from sub-shell"
+          step_name: "Notify with custom message coming from sub-shell and template variable"
+          event: always
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Current Job: $CIRCLE_JOB"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "$(cat /tmp/msg)"
+                  }
+                }
+              ]
+            }
+      - slack/notify:
+          debug: true
+          step_name: "Notify with only custom message coming from sub-shell"
           event: always
           custom: |
             {

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -160,6 +160,19 @@ jobs:
                 }
               ]
             }
+      - run:
+          name: Export value to file
+          command: |
+            printf '%s\n' "Hello There!" > /tmp/msg
+      - slack/notify:
+          debug: true
+          step_name: "Notify with custom message coming from sub-shell"
+          event: always
+          custom: |
+            {
+              "type": "mrkdwn",
+              "text": "$(cat /tmp/msg)"
+            }
 
 workflows:
   test-deploy:

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -196,7 +196,7 @@ SanitizeVars() {
 
   # Extract the variable names from the matches.
   local variable_names
-  variable_names="$(printf '%s\n' "$variables" | grep -o -E '[a-zA-Z0-9_]*')"
+  variable_names="$(printf '%s\n' "$variables" | grep -o -E '[a-zA-Z0-9_]+' || true)"
   [ -z "$variable_names" ] && { printf '%s\n' "Nothing to sanitize."; return 0; }
 
   # Find out what OS we're running on.

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -196,7 +196,8 @@ SanitizeVars() {
 
   # Extract the variable names from the matches.
   local variable_names
-  variable_names="$(printf '%s\n' "$variables" | grep -o -E '[a-zA-Z0-9_]+')"
+  variable_names="$(printf '%s\n' "$variables" | grep -o -E '[a-zA-Z0-9_]*')"
+  [ -z "$variable_names" ] && { printf '%s\n' "Nothing to sanitize."; return 0; }
 
   # Find out what OS we're running on.
   detect_os


### PR DESCRIPTION
# Motivation

- Closes #382

# Changes

- Include `|| true` after the `variable_names` grep to ensure it won't exit.

This ensures grep will succeed even if nothing matches. Thus solving the issue of sub-shells failing the sanitization function.

- Include a condition to exit the function if `variable_names` is empty.

This prevents the function from running without variable names to sanitize.