### PR TITLE
ci: update macos and docker

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -232,10 +232,10 @@ workflows:
 executors:
   cimg:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/base:current
   mac:
     macos:
-      xcode: 11.7.0
+      xcode: 14.0.0
   alpine:
     # This image contains both CURL and JQ
     docker:


### PR DESCRIPTION
Resolve error in testing on Mac due to outdated certificates in the test job environment, breaking CURL.