### PR TITLE
ci: migrate to Orb Tools 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 setup: true
 orbs:
-  orb-tools: circleci/orb-tools@11.4
+  orb-tools: circleci/orb-tools@12.0
   shellcheck: circleci/shellcheck@3.1
   bats: circleci/bats@1.0
 
@@ -24,19 +24,9 @@ workflows:
       - bats/run:
           path: ./src/tests
           filters: *filters
-      - orb-tools/publish:
-          orb-name: circleci/slack
-          vcs-type: << pipeline.project.type >>
-          enable-pr-comment: true
-          github-token: GHI_TOKEN
-          requires:
-            [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check, bats/run]
-          # Use a context to hold your publishing token.
-          context: orb-publisher
-          filters: *filters
-      # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:
-          pipeline-number: << pipeline.number >>
-          vcs-type: << pipeline.project.type >>
-          requires: [orb-tools/publish]
+          orb_name: slack
+          pipeline_number: << pipeline.number >>
+          vcs_type: << pipeline.project.type >>
+          requires: [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check, bats/run]
           filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -206,11 +206,7 @@ workflows:
           matrix:
             parameters:
               runner: [cimg, mac, alpine, windows]
-      - orb-tools/lint:
-          filters: *filters
       - orb-tools/pack:
-          filters: *filters
-      - orb-tools/review:
           filters: *filters
       - orb-tools/publish:
           orb_name: circleci/slack
@@ -218,11 +214,7 @@ workflows:
           pub_type: production
           enable_pr_comment: true
           github_token: GHI_TOKEN
-          requires:
-            - orb-tools/lint
-            - orb-tools/review
-            - orb-tools/pack
-            - integration-test-templates
+          requires: [orb-tools/pack, integration-test-templates]
           context: orb-publisher
           filters:
             branches:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -207,7 +207,11 @@ workflows:
             parameters:
               runner: [cimg, mac, alpine, windows]
       - orb-tools/pack:
-          filters: *filters
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - orb-tools/publish:
           orb_name: circleci/slack
           vcs_type: << pipeline.project.type >>

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -7,6 +7,12 @@ filters: &filters
   tags:
     only: /.*/
 
+release-filters: &release-filters
+  branches:
+    ignore: /.*/
+  tags:
+    only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+
 jobs:
   integration-test-templates:
     parameters:
@@ -207,11 +213,7 @@ workflows:
             parameters:
               runner: [cimg, mac, alpine, windows]
       - orb-tools/pack:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+          filters: *release-filters
       - orb-tools/publish:
           orb_name: circleci/slack
           vcs_type: << pipeline.project.type >>
@@ -220,11 +222,7 @@ workflows:
           github_token: GHI_TOKEN
           requires: [orb-tools/pack, integration-test-templates]
           context: orb-publisher
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+          filters: *release-filters
 executors:
   cimg:
     docker:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
-  slack: circleci/slack@dev:<<pipeline.git.revision>>
-  orb-tools: circleci/orb-tools@11.4
+  orb-tools: circleci/orb-tools@12.0
+  slack: {}
 
 filters: &filters
   tags:
@@ -213,11 +213,11 @@ workflows:
       - orb-tools/review:
           filters: *filters
       - orb-tools/publish:
-          orb-name: circleci/slack
-          vcs-type: << pipeline.project.type >>
-          pub-type: production
-          enable-pr-comment: true
-          github-token: GHI_TOKEN
+          orb_name: circleci/slack
+          vcs_type: << pipeline.project.type >>
+          pub_type: production
+          enable_pr_comment: true
+          github_token: GHI_TOKEN
           requires:
             - orb-tools/lint
             - orb-tools/review

--- a/src/examples/full_deployment_sample.yml
+++ b/src/examples/full_deployment_sample.yml
@@ -38,7 +38,7 @@ usage:
         # When we are on a tagged commit (example "v1.0.0"), we want to also place the workflow on-hold, pending manual approval for deployment.
         # We will also make use of the Slack orb's "on-hold" job to notify us to this on-hold workflow, making it easy to respond.
         # Add a context containing your Slack OAuth token and optionally, default slack channel
-        - slack/on-hold:
+        - slack/on_hold:
             context: slack-secrets
             requires:
               - test
@@ -51,7 +51,7 @@ usage:
             type: approval
             requires:
               - test
-              - slack/on-hold
+              - slack/on_hold
             filters:
               tags:
                 only: /^v.*/

--- a/src/examples/on_hold_notification.yml
+++ b/src/examples/on_hold_notification.yml
@@ -9,7 +9,7 @@ usage:
       jobs:
         - my_test_job
         # Send a slack notfication alerting the workflow will now be placed on-hold after this notification.
-        - slack/on-hold:
+        - slack/on_hold:
             context: slack-secrets
             requires:
               - my_test_job
@@ -19,7 +19,7 @@ usage:
             type: approval
             requires:
               - my_test_job
-              - slack/on-hold
+              - slack/on_hold
         # This job will continue once the workflow has been manually approved.
         - my_deploy_job:
             requires:

--- a/src/jobs/on_hold.yml
+++ b/src/jobs/on_hold.yml
@@ -70,4 +70,3 @@ steps:
       debug: <<parameters.debug>>
       circleci_host: <<parameters.circleci_host>>
       step_name: <<parameters.step_name>>
-


### PR DESCRIPTION
## Description

This PR updates the Slack Orb to the new major version of Orb Tools. As it contains breaking changes, several modifications were unnecessary to move from v11 to [v12](https://circleci.com/developer/orbs/orb/circleci/orb-tools). 

## Changes

The comprehensive list of changes can be found below.

### Changes in `.circleci/config.yml`:

1. Update the orb-tools version from 11.4 to 12.0.
1. Remove the `orb-tools/publish` job since development versions are no longer necessary.
1. Move the job requirement list from `orb-tools/publish` to `orb-tools/continue`.
1. Rename the `orb-tools/continue` job parameters to comply with the new snake case standard.
   - `orb_name`, `pipeline_number` and `vcs_type`.
1. Add the new `orb_name` parameter in `orb-tools/continue`.

### Changes in `.circleci/test-deploy.yml`:

1. Update the orb-tools version from 11.4 to 12.0.
1. Remove the `slack: circleci/slack@dev:<<pipeline.git.revision>>` line, and replace it with `slack: {}`.
1. Remove the `orb-tools/lint`, `orb-tools/pack`, and `orb-tools/review` jobs. ⚠️ 
1. Rename the `orb-tools/publish` job parameters to comply with the new snake case standard.
   - `orb_name`, `vcs_type`, `pub_type`, `enable_pr_comment` and `github_token`.
1. Change the `orb-tools/pack` filter to trigger only on tagged releases.
 
 ### Changes in `src/examples/full_deployment_sample.yml`:

1. Replace `slack/on-hold` with `slack/on_hold` to comply with the new snake case standard.

 ### Changes in `src/examples/on_hold_notification.yml`:

1. Replace `slack/on-hold` with `slack/on_hold` to comply with the new snake case standard.

---

⚠️: This change is not related to the migration itself. These jobs were redundant in `test-deploy.yml` as they already run in `config.yml`. See [Orb-Template #2](https://github.com/CircleCI-Public/Orb-Template/pull/2/files).