### PR TITLE
fix: add removal of carriage return during sanitization

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -127,6 +127,26 @@ jobs:
               ]
             }
       - run:
+          name: Export variable with a multiline string and carriage
+          command: |
+            printf '%s\n' 'export MULTILINE_STRING_CARRIAGE=$(printf "%s\\r\\n" "Line 1." "Line 2." "Line 3.")' >> "$BASH_ENV"
+      - slack/notify:
+          debug: true
+          step_name: "Notify with multiline string and carriage"
+          event: pass
+          custom: >
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "This message should show over multiple lines despite carriage: $MULTILINE_STRING_CARRIAGE"
+                  }
+                }
+              ]
+            }
+      - run:
           name: Export variable with double quotes
           command: |
             printf '%s\n' 'export DOUBLE_QUOTES_STRING=$(printf "%s\\n" "Hello There! My name is \"Potato\"")' >> "$BASH_ENV"

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -215,7 +215,7 @@ SanitizeVars() {
     # Escape backslashes.
     sanitized_value="$(printf '%s' "$sanitized_value" | awk '{gsub(/\\/, "&\\"); print $0}')"
     # Escape newlines.
-    sanitized_value="$(printf '%s' "$sanitized_value" | awk 'NR > 1 { printf("\\n") } { printf("%s", $0) }')"
+    sanitized_value="$(printf '%s' "$sanitized_value" | tr -d '\r' | awk 'NR > 1 { printf("\\n") } { printf("%s", $0) }')"
     # Escape double quotes.
     if [ "$PLATFORM" = "windows" ]; then
         sanitized_value="$(printf '%s' "$sanitized_value" | awk '{gsub(/"/, "\\\""); print $0}')"

--- a/src/tests/notify.bats
+++ b/src/tests/notify.bats
@@ -153,3 +153,14 @@ setup() {
     printf '%s\n' "Expected: $EXPECTED" "Actual: $CIRCLE_JOB"
     [ "$CIRCLE_JOB" = "$EXPECTED" ] # Backslashes should be escaped
 }
+
+@test "18: Sanitize - Remove carriage returns in environment variables" {
+    MESSAGE="$(cat $BATS_TEST_DIRNAME/sampleVariableWithCRLF.txt)"
+    SLACK_PARAM_CUSTOM='{"text": "${MESSAGE}"}'
+    SLACK_DEFAULT_CHANNEL="xyz"
+    BuildMessageBody
+
+    EXPECTED=$(echo "{ \"text\": \"Multiline Message 1\nMultiline Message 2\", \"channel\": \"$SLACK_DEFAULT_CHANNEL\" }" | jq)
+    printf '%s\n' "Expected: $EXPECTED" "Actual: $SLACK_MSG_BODY"
+    [ "$SLACK_MSG_BODY" = "$EXPECTED" ] # CRLF should be escaped
+}

--- a/src/tests/sampleVariableWithCRLF.txt
+++ b/src/tests/sampleVariableWithCRLF.txt
@@ -1,0 +1,2 @@
+Multiline Message 1
+Multiline Message 2


### PR DESCRIPTION
## Description
This pull request fixes the issue where variables used within a custom template contain CRLF-style new lines (ie `\r\n`).

A fix and test are added to test against this using a file with multiline content set to use `CRLF` for line endings.

A production use case for this issue is when one wants to send a Slack notification with a multiline commit message from GitHub. If the message was fetched using `git show --pretty=format:%B --no-patch`, the new lines uses `\r\n`.

