### PR TITLE
fix: re-running pipelines

### DIFF
--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -103,7 +103,8 @@ steps:
       steps:
         - restore_cache:
             keys:
-              - cache-<< parameters.thread_id >>-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+              - cache-{{ .Revision }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+              - cache-{{ .Revision }}
   - run:
       when: always
       name: << parameters.step_name >>
@@ -134,6 +135,10 @@ steps:
           equal: [ "", <<parameters.thread_id>> ]
       steps:
         - save_cache:
-            key: cache-<< parameters.thread_id >>-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+            key: cache-{{ .Revision }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+            paths:
+              - /tmp/SLACK_THREAD_INFO
+        - save_cache:
+            key: cache-{{ .Revision }}
             paths:
               - /tmp/SLACK_THREAD_INFO

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -103,8 +103,7 @@ steps:
       steps:
         - restore_cache:
             keys:
-              - cache-{{ .Revision }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
-              - cache-{{ .Revision }}
+              - cache-{{ .Environment.CIRCLE_PIPELINE_ID }}
   - run:
       when: always
       name: << parameters.step_name >>
@@ -135,10 +134,6 @@ steps:
           equal: [ "", <<parameters.thread_id>> ]
       steps:
         - save_cache:
-            key: cache-{{ .Revision }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
-            paths:
-              - /tmp/SLACK_THREAD_INFO
-        - save_cache:
-            key: cache-{{ .Revision }}
+            key: cache-{{ .Environment.CIRCLE_PIPELINE_ID }}
             paths:
               - /tmp/SLACK_THREAD_INFO

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -103,7 +103,7 @@ steps:
       steps:
         - restore_cache:
             keys:
-              - cache-{{ .Environment.CIRCLE_PIPELINE_ID }}
+              - cache-<< parameters.thread_id >>-{{ .Environment.CIRCLE_PIPELINE_ID }}
   - run:
       when: always
       name: << parameters.step_name >>
@@ -134,6 +134,6 @@ steps:
           equal: [ "", <<parameters.thread_id>> ]
       steps:
         - save_cache:
-            key: cache-{{ .Environment.CIRCLE_PIPELINE_ID }}
+            key: cache-<< parameters.thread_id >>-{{ .Environment.CIRCLE_PIPELINE_ID }}
             paths:
               - /tmp/SLACK_THREAD_INFO


### PR DESCRIPTION
Description:

This is a fix for the latest thread message posting capability.

Motivation:

There is a misbehaviour when there is a Slack message posted but the pipeline fails. In these occasions, if a user initiates a  "Rerun from failed" and the failed job actually passes and the pipeline gets to the slack job, intended to post a message in a thread, the message will be posted as a new one.
This is because of the way the cache key is formed (`{{ .Environment.CIRCLE_WORKFLOW_ID }}`) which is different when rerunning the pipeline.
This PR adds another cache key to be relied on in such scenarios. It will now be falling back to using the git revision, which will be the same with every rerun of the pipeline.

Checklist:
[x] All new jobs, commands, executors, parameters have descriptions.
[ ] Usage Example version numbers have been updated.
[ ] Changelog has been updated.