### PR TITLE
fix: `thread_id` cache should work for all event types

### DIFF
--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -104,6 +104,7 @@ steps:
         - restore_cache:
             keys:
               - cache-<< parameters.thread_id >>-{{ .Environment.CIRCLE_PIPELINE_ID }}
+            when: always
   - run:
       when: always
       name: << parameters.step_name >>
@@ -137,3 +138,4 @@ steps:
             key: cache-<< parameters.thread_id >>-{{ .Environment.CIRCLE_PIPELINE_ID }}
             paths:
               - /tmp/SLACK_THREAD_INFO
+            when: always


### PR DESCRIPTION
Right now, if the event type is `fail`, the `thread_id` will be ignored because the `save_cache` and `restore_cache` steps do not have `when` set, meaning they default to `on_success` and do not run.

This PR changes the cache steps so that they always run (on the condition that `thread_id` is being set, anyway).