### PR TITLE
feat: add scheduling messages (#452)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,32 @@ Post replies in threads with a special parameter `thread_id`. Including this par
         }
 ```
 
+## Scheduled Message
+
+Set the `scheduled_offset_seconds` special parameter to a number of seconds if you want to post a scheduled message. Example:
+
+  ```yaml
+- slack/notify:
+      event: always
+      scheduled_offset_seconds: 30
+      custom: |
+        {
+          "blocks": [
+            {
+              "type": "section",
+              "fields": [
+                {
+                  "type": "plain_text",
+                  "text": "*This is a text notification*",
+                  "emoji": true
+                }
+              ]
+            }
+          ]
+        }
+  ```
+
+
 ---
 
 ## FAQ

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -85,11 +85,11 @@ parameters:
       Any subsequent `notify` usage with the same identifier will be posted within the initial message's thread.
       `thread_id` should be set to any arbitrary string to help you identify different threads. See examples for more information.
       Enabling thread messages with this parameter implies using a very small amount of cacheing: ~200 B
-  post_at:
-    type: integer
-    default: ""
-    description: |
-      When set, the notification is a scheduled message. It will appear as a Slack message at the given Unix timestamp.
+    scheduled_offset_seconds:
+      type: integer
+      default: 0
+      description: |
+        When set, the notification is a scheduled message.
 steps:
   - run:
       when: on_fail
@@ -126,7 +126,7 @@ steps:
         SLACK_PARAM_DEBUG: "<<parameters.debug>>"
         SLACK_PARAM_CIRCLECI_HOST: "<<parameters.circleci_host>>"
         SLACK_PARAM_THREAD: "<<parameters.thread_id>>"
-        SLACK_PARAM_POSTAT: "<<parameters.post_at>>"
+        SLACK_PARAM_OFFSET: "<<parameters.scheduled_offset_seconds>>"
         SLACK_SCRIPT_NOTIFY: "<<include(scripts/notify.sh)>>"
         SLACK_SCRIPT_UTILS: "<<include(scripts/utils.sh)>>"
         # import pre-built templates using the orb-pack local script include.

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -85,6 +85,11 @@ parameters:
       Any subsequent `notify` usage with the same identifier will be posted within the initial message's thread.
       `thread_id` should be set to any arbitrary string to help you identify different threads. See examples for more information.
       Enabling thread messages with this parameter implies using a very small amount of cacheing: ~200 B
+  post_at:
+    type: integer
+    default: ""
+    description: |
+      When set, the notification is a scheduled message. It will appear as a Slack message at the given Unix timestamp.
 steps:
   - run:
       when: on_fail
@@ -121,6 +126,7 @@ steps:
         SLACK_PARAM_DEBUG: "<<parameters.debug>>"
         SLACK_PARAM_CIRCLECI_HOST: "<<parameters.circleci_host>>"
         SLACK_PARAM_THREAD: "<<parameters.thread_id>>"
+        SLACK_PARAM_POSTAT: "<<parameters.post_at>>"
         SLACK_SCRIPT_NOTIFY: "<<include(scripts/notify.sh)>>"
         SLACK_SCRIPT_UTILS: "<<include(scripts/utils.sh)>>"
         # import pre-built templates using the orb-pack local script include.

--- a/src/examples/scheduled_scheduled.yml
+++ b/src/examples/scheduled_scheduled.yml
@@ -1,0 +1,37 @@
+description: |
+  Send a custom notification using Slack's Block Kit Builder.
+  Create the payload code and paste it in your notify command's custom parameter.
+  Detailed instructions in the GitHub readme.
+  https://app.slack.com/block-kit-builder
+usage:
+  version: 2.1
+  orbs:
+    slack: circleci/slack@4.1
+  jobs:
+    scheduled_notify:
+      docker:
+        - image: cimg/base:stable
+      steps:
+        - slack/notify:
+            event: always
+            scheduled_offset_seconds: 30 # 30 seconds after the job starts
+            custom: |
+              {
+                "blocks": [
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "*This is a scheduled text notification*",
+                        "emoji": true
+                      }
+                    ]
+                  }
+                ]
+              }
+  workflows:
+    send-notification:
+      jobs:
+        - scheduled_notify:
+            context: slack-secrets

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -76,7 +76,13 @@ PostToSlack() {
             echo "The message body being sent to Slack can be found below. To view redacted values, rerun the job with SSH and access: ${SLACK_MSG_BODY_LOG}"
             echo "$SLACK_MSG_BODY"
         fi
-        SLACK_SENT_RESPONSE=$(curl -s -f -X POST -H 'Content-type: application/json' -H "Authorization: Bearer $SLACK_ACCESS_TOKEN" --data "$SLACK_MSG_BODY" https://slack.com/api/chat.postMessage)
+
+        if [ -n "${SLACK_PARAM_POSTAT:-}" ]; then
+            SLACK_MSG_BODY=$(echo "$SLACK_MSG_BODY" | jq --arg post_at "$SLACK_PARAM_POSTAT" '.post_at = $post_at')
+            SLACK_SENT_RESPONSE=$(curl -s -f -X POST -H 'Content-type: application/json' -H "Authorization: Bearer $SLACK_ACCESS_TOKEN" --data "$SLACK_MSG_BODY" https://slack.com/api/chat.scheduleMessage)
+        else
+            SLACK_SENT_RESPONSE=$(curl -s -f -X POST -H 'Content-type: application/json' -H "Authorization: Bearer $SLACK_ACCESS_TOKEN" --data "$SLACK_MSG_BODY" https://slack.com/api/chat.postMessage)
+        fi
 
         if [ "$SLACK_PARAM_DEBUG" -eq 1 ]; then
             printf "%s\n" "$SLACK_SENT_RESPONSE" > "$SLACK_SENT_RESPONSE_LOG"


### PR DESCRIPTION
# Description

This pull request add a new parameter `scheduled_offset_seconds` to the `notify` command. This parameter has a default value of 0.

If not 0, `notify.sh` script will call [chat.scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) instead of [chat.postMessage](https://api.slack.com/methods/chat.postMessage)