### PR TITLE
Add thread_id to on-hold job

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -239,6 +239,7 @@ workflows:
             parameters:
               runner: [cimg, mac, alpine, windows]
       - slack/on-hold:
+          context: SLACK_NOTIFICATIONS_TEST
           debug: true
           step_name: "On hold with thread"
           template: basic_success_1

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -24,6 +24,12 @@ jobs:
       - checkout
       - slack/notify:
           debug: true
+          step_name: "Initial message with thread"
+          template: basic_success_1
+          event: always
+          thread_id: orb-testing-thread-<${CIRCLE_SHA1}>
+      - slack/notify:
+          debug: true
           step_name: "Custom template with group mention"
           event: always
           custom: |
@@ -60,17 +66,6 @@ jobs:
           step_name: "Success template with mentions"
           template: basic_success_1
           event: always
-      - slack/notify:
-          debug: true
-          step_name: "Initial message with thread"
-          template: basic_success_1
-          event: always
-          thread_id: orb-testing-thread-<${CIRCLE_SHA1}>
-      - slack/on-hold:
-          debug: true
-          step_name: "On hold with thread"
-          template: basic_success_1
-          thread_id: orb-testing-thread-<${CIRCLE_SHA1}>
       - slack/notify:
           debug: true
           step_name: "Success tagged template"
@@ -243,6 +238,14 @@ workflows:
           matrix:
             parameters:
               runner: [cimg, mac, alpine, windows]
+      - slack/on-hold:
+          debug: true
+          step_name: "On hold with thread"
+          template: basic_success_1
+          thread_id: orb-testing-thread-<${CIRCLE_SHA1}>-<<matrix.executor>>
+          matrix:
+            parameters:
+              executor: [cimg, mac, alpine, windows]
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -65,12 +65,12 @@ jobs:
           step_name: "Initial message with thread"
           template: basic_success_1
           event: always
-          threa_id: orb-testing-thread-<${CIRCLE_SHA1}>
+          thread_id: orb-testing-thread-<${CIRCLE_SHA1}>
       - slack/on-hold:
           debug: true
           step_name: "On hold with thread"
           template: basic_success_1
-          threa_id: orb-testing-thread-<${CIRCLE_SHA1}>
+          thread_id: orb-testing-thread-<${CIRCLE_SHA1}>
       - slack/notify:
           debug: true
           step_name: "Success tagged template"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -242,10 +242,7 @@ workflows:
           debug: true
           step_name: "On hold with thread"
           template: basic_success_1
-          thread_id: orb-testing-thread-<${CIRCLE_SHA1}>-<<matrix.executor>>
-          matrix:
-            parameters:
-              executor: [cimg, mac, alpine, windows]
+          thread_id: orb-testing-thread-<${CIRCLE_SHA1}>
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -62,6 +62,17 @@ jobs:
           event: always
       - slack/notify:
           debug: true
+          step_name: "Initial message with thread"
+          template: basic_success_1
+          event: always
+          threa_id: orb-testing-thread-<${CIRCLE_SHA1}>
+      - slack/on-hold:
+          debug: true
+          step_name: "On hold with thread"
+          template: basic_success_1
+          threa_id: orb-testing-thread-<${CIRCLE_SHA1}>
+      - slack/notify:
+          debug: true
           step_name: "Success tagged template"
           template: success_tagged_deploy_1
           event: always

--- a/src/jobs/on-hold.yml
+++ b/src/jobs/on-hold.yml
@@ -62,7 +62,7 @@ parameters:
       When set, the first `notify` with a given `thread_id` will appear as a regular slack message.
       Any subsequent `notify` usage with the same identifier will be posted within the initial message's thread.
       `thread_id` should be set to any arbitrary string to help you identify different threads. See examples for more information.
-      Enabling thread messages with this parameter implies using a very small amount of cacheing: ~200 B    
+      Enabling thread messages with this parameter implies using a very small amount of cacheing: ~200 B
 
 docker:
   - image: cimg/base:stable

--- a/src/jobs/on-hold.yml
+++ b/src/jobs/on-hold.yml
@@ -55,6 +55,14 @@ parameters:
     type: string
     default: Slack - Sending Notification
     description: Specify a custom step name for this command, if desired
+  thread_id:
+    type: string
+    default: ""
+    description: |
+      When set, the first `notify` with a given `thread_id` will appear as a regular slack message.
+      Any subsequent `notify` usage with the same identifier will be posted within the initial message's thread.
+      `thread_id` should be set to any arbitrary string to help you identify different threads. See examples for more information.
+      Enabling thread messages with this parameter implies using a very small amount of cacheing: ~200 B    
 
 docker:
   - image: cimg/base:stable
@@ -72,3 +80,4 @@ steps:
       debug: <<parameters.debug>>
       circleci_host: <<parameters.circleci_host>>
       step_name: <<parameters.step_name>>
+      thread_id: <<parameters.thread_id>>


### PR DESCRIPTION
As indicated in #451 the on-hold job doesn't support the thread_id parameter, it makes sense to have it, as the on-hold job is just a call to the notify command and both should offer the same capabilities.