### PR TITLE
Remove default values for tag and branch patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The Slack Orb comes with a number of included templates to get your started with
 
 Limit Slack notifications to particular branches with the "branch_pattern" or "tag_pattern" parameter.
 
-A comma separated list of regex matchable branch or tag names. Notifications will only be sent if sent from a job from these branches/tags. By default ".+" will be used to match all branches/tags. Pattern must match the full string, no partial matches. Keep in mind that "branch_pattern" and "tag_pattern" are mutually exclusive.
+A comma separated list of regex matchable branch or tag names. Notifications will only be sent if sent from a job from these branches/tags. Pattern must match the full string, no partial matches. Keep in mind that "branch_pattern" and "tag_pattern" are mutually exclusive.
 
 See [usage examples](https://circleci.com/developer/orbs/orb/circleci/slack#usage-examples).
 

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -29,14 +29,14 @@ parameters:
     default: "always"
   branch_pattern:
     description: |
-      A comma separated list of regex matchable branch names. Notifications will only be sent if sent from a job from these branches. By default ".+" will be used to match all branches. Pattern must match the full string, no partial matches.
+      A comma separated list of regex matchable branch names. Notifications will only be sent if sent from a job from these branches. Pattern must match the full string, no partial matches.
     type: string
-    default: ".+"
+    default: ""
   tag_pattern:
     description: |
-      A comma separated list of regex matchable tag names. Notifications will only be sent if sent from a job from these branches. By default ".+" will be used to match all tags. Pattern must match the full string, no partial matches.
+      A comma separated list of regex matchable tag names. Notifications will only be sent if sent from a job from these branches. Pattern must match the full string, no partial matches.
     type: string
-    default: ".+"
+    default: ""
   invert_match:
     description: |
       Invert the branch and tag patterns.


### PR DESCRIPTION
In #461 it is indicated that the default patterns are causing an issue when the tag is always evaluated and failed to send the notification. Removing the default value would fix this by only evaluating when a pattern is set explicitly.