### PR TITLE
Update examples

### DIFF
--- a/src/examples/custom_notification.yml
+++ b/src/examples/custom_notification.yml
@@ -6,11 +6,11 @@ description: |
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.1
+    slack: circleci/slack@5.0
   jobs:
     notify:
       docker:
-        - image: cimg/base:stable
+        - image: cimg/base:current
       steps:
         - slack/notify:
             event: always

--- a/src/examples/full_deployment_sample.yml
+++ b/src/examples/full_deployment_sample.yml
@@ -5,20 +5,20 @@ description: |
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.1
+    slack: circleci/slack@5.0
   jobs:
     # This "test" job will run on every commit (as per our workflow)
     # We are ok with no notifications sent for this job.
     test:
       docker:
-        - image: cimg/base:stable
+        - image: cimg/base:current
       steps:
         - run: echo "test my app"
     # This "deploy" job will only run on a tagged commit (as per our workflow)
     # We want to be alerted both if this job fails, and when it succeeds.
     deploy:
       docker:
-        - image: cimg/base:stable
+        - image: cimg/base:current
       steps:
         - run: echo "deploy my app"
         # In the event the deployment has failed, alert the engineering team

--- a/src/examples/notify_on_fail_with_template.yml
+++ b/src/examples/notify_on_fail_with_template.yml
@@ -6,7 +6,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.1
+    slack: circleci/slack@5.0
     node: circleci/node:4.1
   jobs:
     deploy:

--- a/src/examples/notify_thread.yml
+++ b/src/examples/notify_thread.yml
@@ -4,7 +4,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.1
+    slack: circleci/slack@5.0
     node: circleci/node:4.1
   jobs:
     test:

--- a/src/examples/notify_two_channels.yml
+++ b/src/examples/notify_two_channels.yml
@@ -8,7 +8,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.1
+    slack: circleci/slack@5.0
     node: circleci/node:4.1
   jobs:
     deploy:

--- a/src/examples/on_hold_notification.yml
+++ b/src/examples/on_hold_notification.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.1
+    slack: circleci/slack@5.0
   workflows:
     on-hold-example:
       jobs:

--- a/src/examples/only_notify_on_branch.yml
+++ b/src/examples/only_notify_on_branch.yml
@@ -5,7 +5,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.1
+    slack: circleci/slack@5.0
   jobs:
     build:
       machine: true

--- a/src/examples/scheduled_scheduled.yml
+++ b/src/examples/scheduled_scheduled.yml
@@ -6,11 +6,11 @@ description: |
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.1
+    slack: circleci/slack@5.0
   jobs:
     scheduled_notify:
       docker:
-        - image: cimg/base:stable
+        - image: cimg/base:current
       steps:
         - slack/notify:
             event: always

--- a/src/examples/successful_tagged_deployment.yml
+++ b/src/examples/successful_tagged_deployment.yml
@@ -5,7 +5,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    slack: circleci/slack@4.1
+    slack: circleci/slack@5.0
     node: circleci/node:4.1
   jobs:
     deploy:


### PR DESCRIPTION
`cimg/base:stable` is >2 years old so I've updated the examples to use `cimg/base:current` along with updating the examples to use the new Slack Orb version.