### PR TITLE
Add string substitution to template and custom parameters

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -76,6 +76,16 @@ jobs:
           step_name: "Basic on hold template"
           template: basic_on_hold_1
           event: always
+      - run:
+          name: Generate and Export Slack Message
+          command: |
+            export SLACK_MESSAGE=$(node src/tests/generate-payload.js | jq -c .)
+            echo "export SLACK_MESSAGE='$SLACK_MESSAGE'" >> $BASH_ENV          
+      - slack/notify:
+          debug: true
+          step_name: "Custom template generated dynamicly"
+          event: pass
+          custom: $SLACK_MESSAGE
       - slack/notify:
           debug: true
           step_name: "Custom template with env var in the message"

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2016,SC3043
 if [[ "$SLACK_PARAM_CUSTOM" == \$* ]]; then
+    echo "Doing substitution custom"
     SLACK_PARAM_CUSTOM="$(eval echo "${SLACK_PARAM_CUSTOM}" | circleci env subst)"
 fi
 if [[ "$SLACK_PARAM_TEMPLATE" == \$* ]]; then
+    echo "Doing substitution template"
     SLACK_PARAM_TEMPLATE="$(eval echo "${SLACK_PARAM_TEMPLATE}" | circleci env subst)"
-fi
-if [[ "$SLACK_PARAM_CHANNEL" == \$* ]]; then
-    SLACK_PARAM_CHANNEL="$(eval echo "${SLACK_PARAM_CUSTOM}" | circleci env subst)"
 fi
 
 if [ "$SLACK_PARAM_DEBUG" -eq 1 ]; then

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2016,SC3043
 
+SLACK_PARAM_CUSTOM="$(eval echo "${SLACK_PARAM_CUSTOM}" | circleci env subst)"
+SLACK_PARAM_TEMPLATE="$(eval echo "${SLACK_PARAM_TEMPLATE}" | circleci env subst)"
+SLACK_PARAM_CHANNEL="$(eval echo "${SLACK_PARAM_CUSTOM}" | circleci env subst)"
+
 if [ "$SLACK_PARAM_DEBUG" -eq 1 ]; then
     set -x
 fi

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2016,SC3043
-
-SLACK_PARAM_CUSTOM="$(eval echo "${SLACK_PARAM_CUSTOM}" | circleci env subst)"
-SLACK_PARAM_TEMPLATE="$(eval echo "${SLACK_PARAM_TEMPLATE}" | circleci env subst)"
-SLACK_PARAM_CHANNEL="$(eval echo "${SLACK_PARAM_CUSTOM}" | circleci env subst)"
+if [[ "$SLACK_PARAM_CUSTOM" == \$* ]]; then
+    SLACK_PARAM_CUSTOM="$(eval echo "${SLACK_PARAM_CUSTOM}" | circleci env subst)"
+fi
+if [[ "$SLACK_PARAM_TEMPLATE" == \$* ]]; then
+    SLACK_PARAM_TEMPLATE="$(eval echo "${SLACK_PARAM_TEMPLATE}" | circleci env subst)"
+fi
+if [[ "$SLACK_PARAM_CHANNEL" == \$* ]]; then
+    SLACK_PARAM_CHANNEL="$(eval echo "${SLACK_PARAM_CUSTOM}" | circleci env subst)"
+fi
 
 if [ "$SLACK_PARAM_DEBUG" -eq 1 ]; then
     set -x

--- a/src/tests/generate-payload.js
+++ b/src/tests/generate-payload.js
@@ -1,0 +1,12 @@
+const payload = {
+    blocks: [
+        {
+            type: "section",
+            text: {
+                type: "plain_text",
+                text: "This message was generated with Javascript",
+            },
+        },
+    ],
+};
+console.log(JSON.stringify(payload)); // Outputs JSON


### PR DESCRIPTION
Resolves #468
Allows to pass environment variables to the parameters Template and custom, this evaluation is only done when the value starts with $ to ensure it is a variable, otherwise it would cause issues.