### PR TITLE
Fix "warning: regexp escape sequence `\"' is not a known regexp operator"

### DIFF
--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -323,11 +323,7 @@ SanitizeVars() {
         # Escape newlines.
         sanitized_value="$(printf '%s' "$sanitized_value" | tr -d '\r' | awk 'NR > 1 { printf("\\n") } { printf("%s", $0) }')"
         # Escape double quotes.
-        if [ "$PLATFORM" = "windows" ]; then
-            sanitized_value="$(printf '%s' "$sanitized_value" | awk '{gsub(/"/, "\\\""); print $0}')"
-        else
-            sanitized_value="$(printf '%s' "$sanitized_value" | awk '{gsub(/\"/, "\\\""); print $0}')"
-        fi
+        sanitized_value="$(printf '%s' "$sanitized_value" | awk '{gsub(/"/, "\\\""); print $0}')"
 
         # Write the sanitized value back to the original variable.
         # shellcheck disable=SC3045 # This is working on Alpine.


### PR DESCRIPTION
Since v5.0.1, awk doesn't treat `\"` as a regexp operator. So the current implementation causes the following warning when using awk >= v5.0.1.

```
awk: cmd. line:1: warning: regexp escape sequence `\"' is not a known regexp operator
```

This PR replaces `\"` to `"` to fix the warning.

Ref: https://github.com/KittyKatt/screenFetch/issues/627