### PR TITLE
Add option to update the contents of a notification instead of posting a threaded reply to it

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -30,6 +30,24 @@ jobs:
           thread_id: orb-testing-thread-<${CIRCLE_SHA1}>
       - slack/notify:
           debug: true
+          step_name: "Message with thread updated"
+          event: always
+          update_notification: true
+          thread_id: orb-testing-thread-<${CIRCLE_SHA1}>
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "This message should be on thread and updating thread"
+                  }
+                }
+              ]
+            }
+      - slack/notify:
+          debug: true
           step_name: "Custom template with group mention"
           event: always
           custom: |

--- a/README.md
+++ b/README.md
@@ -106,6 +106,31 @@ Post replies in threads with a special parameter `thread_id`. Including this par
         }
 ```
 
+## Update Top Level Messages
+
+Update a top level message using the `thread_id` parameter. Can update the top of a threaded message or a standalone message. include the parameter `update_notification: true` to specify that this will be an update of an existing message. If the `thread_id` is missing or not found, the message will be posted as a new message instead.
+
+  ```yaml
+- slack/notify:
+      event: always
+      update_notification: true
+      custom: |
+        {
+          "blocks": [
+            {
+              "type": "section",
+              "fields": [
+                {
+                 "type": "plain_text",
+                  "text": "*This is a text notification*",
+                  "emoji": true
+                }
+              ]
+            }
+          ]
+        }
+  ```
+
 ## Scheduled Message
 
 Set the `scheduled_offset_seconds` special parameter to a number of seconds if you want to post a scheduled message. Example:

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -91,6 +91,10 @@ parameters:
     default: 0
     description: |
       When set, the notification is a scheduled message.
+  update_notification:
+    type: boolean
+    default: false
+    description: When set, the parent notification of the thread is updated
   retries:
     type: integer
     default: 0
@@ -142,6 +146,7 @@ steps:
         SLACK_PARAM_THREAD: "<<parameters.thread_id>>"
         SLACK_PARAM_OFFSET: "<<parameters.scheduled_offset_seconds>>"
         SLACK_SCRIPT_NOTIFY: "<<include(scripts/notify.sh)>>"
+        SLACK_PARAM_UPDATE: "<<parameters.update_notification>>"
         SLACK_SCRIPT_UTILS: "<<include(scripts/utils.sh)>>"
         # import pre-built templates using the orb-pack local script include.
         basic_fail_1: "<<include(message_templates/basic_fail_1.json)>>"

--- a/src/examples/update_notification.yml
+++ b/src/examples/update_notification.yml
@@ -1,0 +1,102 @@
+description: |
+  Send a Slack notification to a channel and use the same message to post replies in a thread.
+  `thread_id` parameter holds a thread identifier in case there are multiple notifications in the pipeline
+usage:
+  version: 2.1
+  orbs:
+    slack: circleci/slack@5.0
+    node: circleci/node:4.1
+  jobs:
+    test:
+      executor:
+        name: node/default
+      steps:
+        - slack/notify:
+            event: always
+            channel: engineering
+            thread_id: testing
+            custom: |
+              {
+                "blocks": [
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "*Tests started.*",
+                        "emoji": true
+                      }
+                    ]
+                  }
+                ]
+              }
+        - slack/notify:
+            event: always
+            channel: engineering
+            thread_id: testing
+            update_notification: true
+            custom: |
+              {
+                "blocks": [
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "*Tests finished.*",
+                        "emoji": true
+                      }
+                    ]
+                  }
+                ]
+              }
+    deploy:
+      executor:
+        name: node/default
+      steps:
+        - slack/notify:
+            event: always
+            channel: engineering
+            thread_id: deployment
+            custom: |
+              {
+                "blocks": [
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "*Deployment started.*",
+                        "emoji": true
+                      }
+                    ]
+                  }
+                ]
+              }
+        - slack/notify:
+            event: always
+            channel: engineering
+            thread_id: deployment
+            update_notification: true
+            custom: |
+              {
+                "blocks": [
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "*Deployment finished.*",
+                        "emoji": true
+                      }
+                    ]
+                  }
+                ]
+              }
+  workflows:
+    deploy_and_notify:
+      jobs:
+        - deploy
+        - test:
+            requires:
+              - deploy

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -101,7 +101,7 @@ PostToSlack() {
             # get the value of the specified thread from the environment
             # SLACK_THREAD_TS=12345.12345
             SLACK_THREAD_TS=$(eval "echo \"\$$SLACK_PARAM_THREAD\"")
-            if [ $SLACK_PARAM_UPDATE ]; then
+            if [ "$SLACK_PARAM_UPDATE" ]; then
                 # when updating, the key ts is used to reference the message to be updated
                 TS=$(eval "echo \"\$$SLACK_PARAM_THREAD\"")
                 SLACK_MSG_BODY=$(echo "$SLACK_MSG_BODY" | jq --arg ts "$TS" '.ts = $ts')


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:
add `update_notification` flag to `notify` job, which will update the top level message in the thread instead of appending a new message to the bottom of the thread. If no thread is found or no thread is specified, defaults to a regular notification posting.
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

also added a charset to the slack api curl statement to address the `missing charset` warning from the slack api

## Motivation:
By updating the top level message instead of posting threaded replied, it is easy to update the progress of a job without sending new notifications for each update. This also allows for links or actions to be "enabled" after the job completes, such as when a deploy is successful, providing next steps and additional info in the top level message. 
<!---
  Share any open issues this PR references or otherwise describe the motivation to submit this pull request.
 -->
not dissimilar to https://github.com/CircleCI-Public/slack-orb/pull/466/files
 **Closes Issues:**
-  ISSUE URL

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.