### PR TITLE
Added Unfurl Links and Media properties

### DIFF
--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -99,6 +99,18 @@ parameters:
       type: integer
       default: 30
       description: The amount of seconds to wait between retries. Defaults to 30.
+  unfurl_links:
+      description: |
+       Attach content preview when the message containing a link. This allows adding context and continuity to conversations.
+       Link unfurling is the default treatment for links posted in Slack. When a link is spotted, Slack crawls it and provides a preview.
+      type: boolean
+      default: true
+  unfurl_media:
+      description: |
+       Attach content preview when the message containing a media link. This allows adding context and continuity to conversations.
+       Media unfurling is the default treatment for links posted in Slack. When a media link is spotted, Slack crawls it and provides a preview.
+      type: boolean
+      default: true
 steps:
   - run:
       shell: bash -eo pipefail
@@ -141,6 +153,8 @@ steps:
         SLACK_PARAM_CIRCLECI_HOST: "<<parameters.circleci_host>>"
         SLACK_PARAM_THREAD: "<<parameters.thread_id>>"
         SLACK_PARAM_OFFSET: "<<parameters.scheduled_offset_seconds>>"
+        SLACK_PARAM_UNFURL_LINKS: "<<parameters.unfurl_links>>"
+        SLACK_PARAM_UNFURL_MEDIA: "<<parameters.unfurl_media>>"
         SLACK_SCRIPT_NOTIFY: "<<include(scripts/notify.sh)>>"
         SLACK_SCRIPT_UTILS: "<<include(scripts/utils.sh)>>"
         # import pre-built templates using the orb-pack local script include.

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -54,12 +54,12 @@ BuildMessageBody() {
     T2="$(printf '%s' "$T2" | jq ". + {\"channel\": \"$SLACK_DEFAULT_CHANNEL\"}")"
 
     echo "Unfurl Link: $SLACK_PARAM_UNFURL_LINKS"
-    if [ $SLACK_PARAM_UNFURL_LINKS -eq 0 ] ; then
+    if [ "$SLACK_PARAM_UNFURL_LINKS" -eq 0 ] ; then
         T2=$(echo "$T2" | jq '.unfurl_links = false')
     fi
 
     echo "Unfurl Media: $SLACK_PARAM_UNFURL_MEDIA"
-    if [ $SLACK_PARAM_UNFURL_MEDIA -eq 0 ] ; then
+    if [ "$SLACK_PARAM_UNFURL_MEDIA" -eq 0 ] ; then
         T2=$(echo "$T2" | jq '.unfurl_media = false')
     fi
 

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -52,6 +52,17 @@ BuildMessageBody() {
 
     # Insert the default channel. THIS IS TEMPORARY
     T2="$(printf '%s' "$T2" | jq ". + {\"channel\": \"$SLACK_DEFAULT_CHANNEL\"}")"
+
+    echo "Unfurl Link: $SLACK_PARAM_UNFURL_LINKS"
+    if [ $SLACK_PARAM_UNFURL_LINKS -eq 0 ] ; then
+        T2=$(echo "$T2" | jq '.unfurl_links = false')
+    fi
+
+    echo "Unfurl Media: $SLACK_PARAM_UNFURL_MEDIA"
+    if [ $SLACK_PARAM_UNFURL_MEDIA -eq 0 ] ; then
+        T2=$(echo "$T2" | jq '.unfurl_media = false')
+    fi
+
     SLACK_MSG_BODY="$T2"
 }
 

--- a/src/scripts/utils.sh
+++ b/src/scripts/utils.sh
@@ -20,6 +20,6 @@ detect_os() {
       exit 1
       ;;
   esac
-
-  export readonly PLATFORM
+  readonly PLATFORM
+  export PLATFORM
 }

--- a/src/tests/notify.bats
+++ b/src/tests/notify.bats
@@ -164,3 +164,25 @@ setup() {
     printf '%s\n' "Expected: $EXPECTED" "Actual: $SLACK_MSG_BODY"
     [ "$SLACK_MSG_BODY" = "$EXPECTED" ] # CRLF should be escaped
 }
+
+@test "19: Unfurlr Link - Disable link unfurl" {
+    TESTLINKURL="http://circleci.com"
+    SLACK_PARAM_CUSTOM=$(cat $BATS_TEST_DIRNAME/sampleCustomTemplateWithLink.json)
+    SLACK_DEFAULT_CHANNEL="xyz"
+    SLACK_PARAM_UNFURL_LINKS=0
+    BuildMessageBody
+    EXPECTED=$(echo "{ \"blocks\": [ { \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"Sample link using environment variable in markdown <${TESTLINKURL}|LINK >\" } } ], \"text\": \"\", \"channel\": \"$SLACK_DEFAULT_CHANNEL\", \"unfurl_links\": false }" | jq)
+    printf '%s\n' "Expected: $EXPECTED" "Actual: $SLACK_MSG_BODY"
+    [ "$SLACK_MSG_BODY" == "$EXPECTED" ]
+}
+
+@test "20: Unfurl Media - Disable media unfurl" {
+    TESTLINKURL="http://circleci.com"
+    SLACK_PARAM_CUSTOM=$(cat $BATS_TEST_DIRNAME/sampleCustomTemplateWithLink.json)
+    SLACK_DEFAULT_CHANNEL="xyz"
+    SLACK_PARAM_UNFURL_MEDIA=0
+    BuildMessageBody
+    EXPECTED=$(echo "{ \"blocks\": [ { \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"Sample link using environment variable in markdown <${TESTLINKURL}|LINK >\" } } ], \"text\": \"\", \"channel\": \"$SLACK_DEFAULT_CHANNEL\", \"unfurl_media\": false }" | jq)
+    printf '%s\n' "Expected: $EXPECTED" "Actual: $SLACK_MSG_BODY"
+    [ "$SLACK_MSG_BODY" == "$EXPECTED" ]
+}


### PR DESCRIPTION
Slack attaches a preview if a link or a media URL is included as part of the message by default as described in [the documentation](https://api.slack.com/reference/messaging/link-unfurling)
The following changes makes this behavior optional as it is supported by the API.

* Adds a new set of parameters in the `notify` command.
* Those parameters are sent to the `notify.sh` script.
* Adds a couple of tests to review the message generation.

Testing message with and without unfurl:
<img width="587" alt="image" src="https://github.com/user-attachments/assets/70d21022-18f5-4e25-ab6d-eeef1216e249" />


Closes #479