### PR TITLE
feat: add event and tag matching support to reactions

### DIFF
--- a/src/commands/reaction.yml
+++ b/src/commands/reaction.yml
@@ -25,6 +25,28 @@ parameters:
     default: false
     description: Runs scripts in debug mode for bash (set -x).
     type: boolean
+  event:
+    description: |
+      In what event should this message send? Options: ["fail", "pass", "always"]
+    type: enum
+    enum: ["fail", "pass", "always"]
+    default: "always"
+  branch_pattern:
+    description: |
+      A comma separated list of regex matchable branch names. Notifications will only be sent if sent from a job from these branches. Pattern must match the full string, no partial matches.
+    type: string
+    default: ""
+  tag_pattern:
+    description: |
+      A comma separated list of regex matchable tag names. Notifications will only be sent if sent from a job from these branches. Pattern must match the full string, no partial matches.
+    type: string
+    default: ""
+  invert_match:
+    description: |
+      Invert the branch and tag patterns.
+      If set to true, notifications will only be sent if sent from a job from branches and tags that do not match the patterns.
+    type: boolean
+    default: false
   windows_execution:
     description: |
       When this command is going to be run on windows, set this to true.
@@ -36,19 +58,26 @@ steps:
         equal: [ false, <<parameters.windows_execution>>]
       steps:
         - run:
+            when: always
             name: << parameters.step_name >>
             command: <<include(scripts/reaction.sh)>>
             environment:
               SLACK_PARAM_CHANNEL: <<parameters.channel>>
               SLACK_PARAM_ADD_REACT_NAME: <<parameters.add_react_name>>
               SLACK_PARAM_REMOVE_REACT_NAME: <<parameters.remove_react_name>>
+              SLACK_PARAM_EVENT: << parameters.event >>
+              SLACK_PARAM_BRANCHPATTERN: <<parameters.branch_pattern>>
+              SLACK_PARAM_TAGPATTERN: <<parameters.tag_pattern>>
+              SLACK_PARAM_INVERT_MATCH: <<parameters.invert_match>>
               SLACK_PARAM_THREAD: <<parameters.thread_id>>
               SLACK_PARAM_DEBUG: << parameters.debug >>
+              SLACK_SCRIPT_UTILS: "<<include(scripts/utils.sh)>>"
   - when:
       condition:
         equal: [ true, <<parameters.windows_execution>>]
       steps:
         - run:
+            when: always
             shell: bash -eo pipefail
             name: << parameters.step_name >>
             command: <<include(scripts/reaction.sh)>>
@@ -56,5 +85,10 @@ steps:
               SLACK_PARAM_CHANNEL: <<parameters.channel>>
               SLACK_PARAM_ADD_REACT_NAME: <<parameters.add_react_name>>
               SLACK_PARAM_REMOVE_REACT_NAME: <<parameters.remove_react_name>>
+              SLACK_PARAM_EVENT: << parameters.event >>
+              SLACK_PARAM_BRANCHPATTERN: <<parameters.branch_pattern>>
+              SLACK_PARAM_TAGPATTERN: <<parameters.tag_pattern>>
+              SLACK_PARAM_INVERT_MATCH: <<parameters.invert_match>>
               SLACK_PARAM_THREAD: <<parameters.thread_id>>
               SLACK_PARAM_DEBUG: << parameters.debug >>
+              SLACK_SCRIPT_UTILS: "<<include(scripts/utils.sh)>>"

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -208,31 +208,6 @@ InstallJq() {
     fi
 }
 
-FilterBy() {
-    if [ -z "$1" ]; then
-        return
-    fi
-    # If any pattern supplied matches the current branch or the current tag, proceed; otherwise, exit with message.
-    FLAG_MATCHES_FILTER="false"
-    # shellcheck disable=SC2001
-    for i in $(echo "$1" | sed "s/,/ /g"); do
-        if echo "$2" | grep -Eq "^${i}$"; then
-            FLAG_MATCHES_FILTER="true"
-            break
-        fi
-    done
-    # If the invert_match parameter is set, invert the match.
-    if { [ "$FLAG_MATCHES_FILTER" = "false" ] && [ "$SLACK_PARAM_INVERT_MATCH" -eq 0 ]; } ||
-        { [ "$FLAG_MATCHES_FILTER" = "true" ] && [ "$SLACK_PARAM_INVERT_MATCH" -eq 1 ]; }; then
-        # dont send message.
-        echo "NO SLACK ALERT"
-        echo
-        echo "Current reference \"$2\" does not match any matching parameter"
-        echo "Current matching pattern: $1"
-        exit 0
-    fi
-}
-
 SetupEnvVars() {
     echo "BASH_ENV file: $BASH_ENV"
     if [ -f "$BASH_ENV" ]; then
@@ -259,24 +234,6 @@ CheckEnvVars() {
     if [ -z "${SLACK_PARAM_CHANNEL:-}" ]; then
         echo "No channel was provided. Enter value for SLACK_DEFAULT_CHANNEL env var, or channel parameter"
         exit 1
-    fi
-}
-
-ShouldPost() {
-    if [ "$CCI_STATUS" = "$SLACK_PARAM_EVENT" ] || [ "$SLACK_PARAM_EVENT" = "always" ]; then
-        # In the event the Slack notification would be sent, first ensure it is allowed to trigger
-        # on this branch or this tag.
-        FilterBy "$SLACK_PARAM_BRANCHPATTERN" "${CIRCLE_BRANCH:-}"
-        FilterBy "$SLACK_PARAM_TAGPATTERN" "${CIRCLE_TAG:-}"
-
-        echo "Posting Status"
-    else
-        # dont send message.
-        echo "NO SLACK ALERT"
-        echo
-        echo "This command is set to send an alert on: $SLACK_PARAM_EVENT"
-        echo "Current status: ${CCI_STATUS}"
-        exit 0
     fi
 }
 

--- a/src/scripts/reaction.sh
+++ b/src/scripts/reaction.sh
@@ -3,6 +3,9 @@ if [ "$SLACK_PARAM_DEBUG" = 1 ]; then
     set -x
 fi
 
+# Import utils.
+eval "$SLACK_SCRIPT_UTILS"
+
 SLACK_PARAM_CHANNEL="$(echo "${SLACK_PARAM_CHANNEL}" | circleci env subst)"
 SLACK_PARAM_ADD_REACT_NAME="$(echo "${SLACK_PARAM_ADD_REACT_NAME}" | circleci env subst)"
 SLACK_PARAM_REMOVE_REACT_NAME="$(echo "${SLACK_PARAM_REMOVE_REACT_NAME}" | circleci env subst)"
@@ -52,5 +55,6 @@ ReactToSlack() {
     fi
 }
 
+ShouldPost
 ReactToSlack
 set +x

--- a/src/scripts/utils.sh
+++ b/src/scripts/utils.sh
@@ -2,6 +2,49 @@
 # shellcheck shell=bash
 # shellcheck disable=SC2154
 
+FilterBy() {
+    if [ -z "$1" ]; then
+        return
+    fi
+    # If any pattern supplied matches the current branch or the current tag, proceed; otherwise, exit with message.
+    FLAG_MATCHES_FILTER="false"
+    # shellcheck disable=SC2001
+    for i in $(echo "$1" | sed "s/,/ /g"); do
+        if echo "$2" | grep -Eq "^${i}$"; then
+            FLAG_MATCHES_FILTER="true"
+            break
+        fi
+    done
+    # If the invert_match parameter is set, invert the match.
+    if { [ "$FLAG_MATCHES_FILTER" = "false" ] && [ "$SLACK_PARAM_INVERT_MATCH" -eq 0 ]; } ||
+        { [ "$FLAG_MATCHES_FILTER" = "true" ] && [ "$SLACK_PARAM_INVERT_MATCH" -eq 1 ]; }; then
+        # dont send message.
+        echo "NO SLACK ALERT"
+        echo
+        echo "Current reference \"$2\" does not match any matching parameter"
+        echo "Current matching pattern: $1"
+        exit 0
+    fi
+}
+
+ShouldPost() {
+    if [ "$CCI_STATUS" = "$SLACK_PARAM_EVENT" ] || [ "$SLACK_PARAM_EVENT" = "always" ]; then
+        # In the event the Slack notification would be sent, first ensure it is allowed to trigger
+        # on this branch or this tag.
+        FilterBy "$SLACK_PARAM_BRANCHPATTERN" "${CIRCLE_BRANCH:-}"
+        FilterBy "$SLACK_PARAM_TAGPATTERN" "${CIRCLE_TAG:-}"
+
+        echo "Posting Status"
+    else
+        # dont send message.
+        echo "NO SLACK ALERT"
+        echo
+        echo "This command is set to send an alert on: $SLACK_PARAM_EVENT"
+        echo "Current status: ${CCI_STATUS}"
+        exit 0
+    fi
+}
+
 detect_os() {
   detected_platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
 


### PR DESCRIPTION
Adds support for only sending reactions on matching branches/tags, and on specific events. An example usecase is using pass/fail to specify :heavy_check_mark: / :x:  as reactions on further steps in a deploy thread.