### PR TITLE
fix: set charset in requests to slack

### DIFF
--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -73,7 +73,7 @@ NotifyWithRetries() {
     local success_request=false
     local retry_count=0
     while [ "$retry_count" -le "$SLACK_PARAM_RETRIES" ]; do
-        if SLACK_SENT_RESPONSE=$(curl -s -f -X POST -H 'Content-type: application/json' -H "Authorization: Bearer $SLACK_ACCESS_TOKEN" --data "$SLACK_MSG_BODY" "$1"); then
+        if SLACK_SENT_RESPONSE=$(curl -s -f -X POST -H 'Content-type: application/json; charset=utf-8' -H "Authorization: Bearer $SLACK_ACCESS_TOKEN" --data "$SLACK_MSG_BODY" "$1"); then
             echo "Notification sent"
             success_request=true
             break


### PR DESCRIPTION
This silences a warning on all responses:
`"warning":"missing_charset"`