### PR TITLE
[WEB-2360] Remove use of imgix URL

### DIFF
--- a/src/message_templates/basic_fail_1.json
+++ b/src/message_templates/basic_fail_1.json
@@ -36,7 +36,7 @@
 			],
 			"accessory": {
 				"type": "image",
-				"image_url": "https://production-cci-com.imgix.net/blog/media/circle-logo-badge-black.png",
+				"image_url": "https://images.ctfassets.net/il1yandlcjgk/1VhtXIX9wwJMh29GurJsYp/5dc5a0ea52c6c35a2b630b462c7d74dd/circle-logo-badge-black.png",
 				"alt_text": "CircleCI logo"
 			}
 		},

--- a/src/message_templates/basic_on_hold_1.json
+++ b/src/message_templates/basic_on_hold_1.json
@@ -27,7 +27,7 @@
 			],
 			"accessory": {
 				"type": "image",
-				"image_url": "https://production-cci-com.imgix.net/blog/media/circle-logo-badge-black.png",
+				"image_url": "https://images.ctfassets.net/il1yandlcjgk/1VhtXIX9wwJMh29GurJsYp/5dc5a0ea52c6c35a2b630b462c7d74dd/circle-logo-badge-black.png",
 				"alt_text": "CircleCI logo"
 			}
 		},

--- a/src/message_templates/basic_success_1.json
+++ b/src/message_templates/basic_success_1.json
@@ -40,7 +40,7 @@
 			],
 			"accessory": {
 				"type": "image",
-				"image_url": "https://production-cci-com.imgix.net/blog/media/circle-logo-badge-black.png",
+				"image_url": "https://images.ctfassets.net/il1yandlcjgk/1VhtXIX9wwJMh29GurJsYp/5dc5a0ea52c6c35a2b630b462c7d74dd/circle-logo-badge-black.png",
 				"alt_text": "CircleCI logo"
 			}
 		},

--- a/src/message_templates/success_tagged_deploy_1.json
+++ b/src/message_templates/success_tagged_deploy_1.json
@@ -27,7 +27,7 @@
 			],
 			"accessory": {
 				"type": "image",
-				"image_url": "https://production-cci-com.imgix.net/blog/media/circle-logo-badge-black.png",
+				"image_url": "https://images.ctfassets.net/il1yandlcjgk/1VhtXIX9wwJMh29GurJsYp/5dc5a0ea52c6c35a2b630b462c7d74dd/circle-logo-badge-black.png",
 				"alt_text": "CircleCI logo"
 			}
 		},


### PR DESCRIPTION
**Ticket**: [WEB-2360](https://circleci.atlassian.net/browse/WEB-2360)

## Changes
* Replace use of Imgix URL with Contentful source

## Rationale
We are discontinuing use of Imgix. Updating this URL will prevent this image from being broken when the Imgix account is disabled.

## Considerations
The original image had no size specified, so the replacement doesn't either.



[WEB-2360]: https://circleci.atlassian.net/browse/WEB-2360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ