### PR TITLE
feat: add api_domain for govslack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,31 @@ Set the `scheduled_offset_seconds` special parameter to a number of seconds if y
         }
   ```
 
+## GovSlack Support
+
+Set the `api_domain` parameter to specify which Slack API domain to use. Use `slack.com` for regular Slack workspaces (default) and `slack-gov.com` for GovSlack workspaces.
+
+  ```yaml
+- slack/notify:
+      event: always
+      api_domain: slack-gov.com
+      custom: |
+        {
+          "blocks": [
+            {
+              "type": "section",
+              "fields": [
+                {
+                  "type": "plain_text",
+                  "text": "*This is a text notification to GovSlack*",
+                  "emoji": true
+                }
+              ]
+            }
+          ]
+        }
+  ```
+
 
 ---
 

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -116,6 +116,11 @@ parameters:
         When this command is going to be run on windows, set this to true.
       type: boolean
       default: false
+  api_domain:
+      description: |
+        Domain for the Slack API. Use slack.com for regular Slack and slack-gov.com for GovSlack.
+      type: string
+      default: "slack.com"
 steps:
   - run:
       when: on_fail
@@ -161,6 +166,7 @@ steps:
               SLACK_PARAM_OFFSET: "<<parameters.scheduled_offset_seconds>>"
               SLACK_PARAM_UNFURL_LINKS: "<<parameters.unfurl_links>>"
               SLACK_PARAM_UNFURL_MEDIA: "<<parameters.unfurl_media>>"
+              SLACK_PARAM_API_DOMAIN: "<<parameters.api_domain>>"
               SLACK_SCRIPT_NOTIFY: "<<include(scripts/notify.sh)>>"
               SLACK_SCRIPT_UTILS: "<<include(scripts/utils.sh)>>"
               # import pre-built templates using the orb-pack local script include.
@@ -195,6 +201,7 @@ steps:
               SLACK_PARAM_OFFSET: "<<parameters.scheduled_offset_seconds>>"
               SLACK_PARAM_UNFURL_LINKS: "<<parameters.unfurl_links>>"
               SLACK_PARAM_UNFURL_MEDIA: "<<parameters.unfurl_media>>"
+              SLACK_PARAM_API_DOMAIN: "<<parameters.api_domain>>"
               SLACK_SCRIPT_NOTIFY: "<<include(scripts/notify.sh)>>"
               SLACK_SCRIPT_UTILS: "<<include(scripts/utils.sh)>>"
               # import pre-built templates using the orb-pack local script include.

--- a/src/commands/reaction.yml
+++ b/src/commands/reaction.yml
@@ -52,6 +52,11 @@ parameters:
       When this command is going to be run on windows, set this to true.
     type: boolean
     default: false
+  api_domain:
+    description: |
+      Domain for the Slack API. Use slack.com for regular Slack and slack-gov.com for GovSlack.
+    type: string
+    default: "slack.com"
 steps:
   - when:
       condition:
@@ -71,6 +76,7 @@ steps:
               SLACK_PARAM_INVERT_MATCH: <<parameters.invert_match>>
               SLACK_PARAM_THREAD: <<parameters.thread_id>>
               SLACK_PARAM_DEBUG: << parameters.debug >>
+              SLACK_PARAM_API_DOMAIN: << parameters.api_domain >>
               SLACK_SCRIPT_UTILS: "<<include(scripts/utils.sh)>>"
   - when:
       condition:
@@ -91,4 +97,5 @@ steps:
               SLACK_PARAM_INVERT_MATCH: <<parameters.invert_match>>
               SLACK_PARAM_THREAD: <<parameters.thread_id>>
               SLACK_PARAM_DEBUG: << parameters.debug >>
+              SLACK_PARAM_API_DOMAIN: << parameters.api_domain >>
               SLACK_SCRIPT_UTILS: "<<include(scripts/utils.sh)>>"

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2016,SC3043
+
+# Set API_DOMAIN from parameter or default to slack.com
+API_DOMAIN="${SLACK_PARAM_API_DOMAIN:-slack.com}"
 if [[ "$SLACK_PARAM_CUSTOM" == \$* ]]; then
     echo "Doing substitution custom"
     SLACK_PARAM_CUSTOM="$(eval echo "${SLACK_PARAM_CUSTOM}" | circleci env subst)"
@@ -141,9 +144,9 @@ PostToSlack() {
             SLACK_MSG_BODY=$(echo "$SLACK_MSG_BODY" | jq --arg post_at "$POST_AT" '.post_at = ($post_at|tonumber)')
             # text is required for scheduled messages
             SLACK_MSG_BODY=$(echo "$SLACK_MSG_BODY" | jq '.text = "Dummy fallback text"')
-            NotifyWithRetries https://slack.com/api/chat.scheduleMessage
+            NotifyWithRetries https://$API_DOMAIN/api/chat.scheduleMessage
         else
-            NotifyWithRetries https://slack.com/api/chat.postMessage
+            NotifyWithRetries https://$API_DOMAIN/api/chat.postMessage
         fi
 
         if [ "$SLACK_PARAM_DEBUG" -eq 1 ]; then

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -144,9 +144,9 @@ PostToSlack() {
             SLACK_MSG_BODY=$(echo "$SLACK_MSG_BODY" | jq --arg post_at "$POST_AT" '.post_at = ($post_at|tonumber)')
             # text is required for scheduled messages
             SLACK_MSG_BODY=$(echo "$SLACK_MSG_BODY" | jq '.text = "Dummy fallback text"')
-            NotifyWithRetries https://$API_DOMAIN/api/chat.scheduleMessage
+            NotifyWithRetries https://"$API_DOMAIN"/api/chat.scheduleMessage
         else
-            NotifyWithRetries https://$API_DOMAIN/api/chat.postMessage
+            NotifyWithRetries https://"$API_DOMAIN"/api/chat.postMessage
         fi
 
         if [ "$SLACK_PARAM_DEBUG" -eq 1 ]; then

--- a/src/scripts/reaction.sh
+++ b/src/scripts/reaction.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+# Set API_DOMAIN from parameter or default to slack.com
+API_DOMAIN="${SLACK_PARAM_API_DOMAIN:-slack.com}"
 if [ "$SLACK_PARAM_DEBUG" = 1 ]; then
     set -x
 fi
@@ -29,7 +32,7 @@ ReactToSlack() {
 
     if [ -n "${SLACK_PARAM_REMOVE_REACT_NAME}" ]; then
         echo "Remove reaction with name=${SLACK_PARAM_REMOVE_REACT_NAME} channel=${SLACK_PARAM_CHANNEL} thread_ts=${SLACK_THREAD_TS}"
-        REMOVE_RESULT=$(curl -X POST --location 'https://slack.com/api/reactions.remove' \
+        REMOVE_RESULT=$(curl -X POST --location "https://$API_DOMAIN/api/reactions.remove" \
             --header 'Content-Type: application/x-www-form-urlencoded' \
             --header "Authorization: Bearer ${SLACK_ACCESS_TOKEN}" \
             --data-urlencode "channel=${SLACK_PARAM_CHANNEL}" \
@@ -42,7 +45,7 @@ ReactToSlack() {
     fi
     if [ -n "${SLACK_PARAM_ADD_REACT_NAME}" ]; then
         echo "Add reaction with name=${SLACK_PARAM_ADD_REACT_NAME} channel=${SLACK_PARAM_CHANNEL} thread_ts=${SLACK_THREAD_TS}"
-        ADD_RESULT=$(curl -X POST --location 'https://slack.com/api/reactions.add' \
+        ADD_RESULT=$(curl -X POST --location "https://$API_DOMAIN/api/reactions.add" \
             --header 'Content-Type: application/x-www-form-urlencoded' \
             --header "Authorization: Bearer ${SLACK_ACCESS_TOKEN}" \
             --data-urlencode "channel=${SLACK_PARAM_CHANNEL}" \


### PR DESCRIPTION
The hardcoded `slack.com` URL prevents the ability to use this orb on instances of GovSlack which uses `slack-gov.com`. For potential future extensibility, I allowed overriding the default `slack.com` with any domain specified by the user. 