### PR TITLE
docs: add example aggregating parallel test results into one notification

### DIFF
--- a/src/examples/notify_aggregated_parallel_results.yml
+++ b/src/examples/notify_aggregated_parallel_results.yml
@@ -3,8 +3,9 @@ description: |
   duplicate notifications for a single logical test run.
   This example shows how to aggregate the results of parallel jobs into a single Slack
   notification by adding a dedicated "notify" job that:
-    1. Runs only after all parallel "test" nodes finish (using `requires` with `[success, failed]`
-       so it runs whether the parallel run passed or failed).
+    1. Runs only after all parallel "test" nodes reach a terminal state (using `requires`
+       with `terminal` so it runs whether the parallel run passed, failed, was canceled,
+       or timed out).
     2. Queries the CircleCI API v2 for the statuses of all "test" job nodes.
     3. Sends exactly one Slack notification reflecting the combined outcome.
   Note: `$CIRCLE_TOKEN` must be provided via a context. Read access to the project is required.
@@ -30,8 +31,10 @@ usage:
                 -H "Circle-Token: $CIRCLE_TOKEN" \
                 "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job")
 
+              # Any non-"success" terminal status (failed, canceled, timedout, infrastructure_fail, ...)
+              # is treated as a failure for notification purposes.
               FAILED=$(echo "$JOBS" | jq '[
-                .items[] | select(.name == "test" and (.status == "failed" or .status == "failing"))
+                .items[] | select(.name == "test" and .status != "success")
               ] | length')
 
               if [ "$FAILED" -gt "0" ]; then
@@ -55,4 +58,4 @@ usage:
         - notify:
             context: slack-secrets
             requires:
-              - test: [success, failed]
+              - test: terminal

--- a/src/examples/notify_aggregated_parallel_results.yml
+++ b/src/examples/notify_aggregated_parallel_results.yml
@@ -1,0 +1,58 @@
+description: |
+  When using `parallelism`, `slack/notify` fires once per parallel node, resulting in
+  duplicate notifications for a single logical test run.
+  This example shows how to aggregate the results of parallel jobs into a single Slack
+  notification by adding a dedicated "notify" job that:
+    1. Runs only after all parallel "test" nodes finish (using `requires` with `[success, failed]`
+       so it runs whether the parallel run passed or failed).
+    2. Queries the CircleCI API v2 for the statuses of all "test" job nodes.
+    3. Sends exactly one Slack notification reflecting the combined outcome.
+  Note: `$CIRCLE_TOKEN` must be provided via a context. Read access to the project is required.
+usage:
+  version: 2.1
+  orbs:
+    slack: circleci/slack@5.0
+  jobs:
+    test:
+      docker:
+        - image: cimg/base:stable
+      parallelism: 6
+      steps:
+        - run: echo "run your parallel tests here"
+    notify:
+      docker:
+        - image: cimg/base:stable
+      steps:
+        - run:
+            name: Aggregate parallel test results
+            command: |
+              JOBS=$(curl -sf \
+                -H "Circle-Token: $CIRCLE_TOKEN" \
+                "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job")
+
+              FAILED=$(echo "$JOBS" | jq '[
+                .items[] | select(.name == "test" and (.status == "failed" or .status == "failing"))
+              ] | length')
+
+              if [ "$FAILED" -gt "0" ]; then
+                echo "$FAILED node(s) failed."
+                exit 1
+              fi
+              echo "All nodes passed."
+        # Sends a failure notification if any parallel "test" node failed.
+        - slack/notify:
+            event: fail
+            template: basic_fail_1
+        # Sends a success notification only when every parallel "test" node succeeded.
+        - slack/notify:
+            event: pass
+            template: basic_success_1
+  workflows:
+    test-and-notify:
+      jobs:
+        - test
+        # Secure your Slack OAuth token and CircleCI API token behind a restricted context.
+        - notify:
+            context: slack-secrets
+            requires:
+              - test: [success, failed]


### PR DESCRIPTION
## Summary

Adds a new example, `src/examples/notify_aggregated_parallel_results.yml`, showing how to send **exactly one** Slack notification for a parallel (`parallelism`) test job — instead of one per node.

The example uses a dedicated `notify` job that:
1. Runs after the parallel `test` job using `requires: - test: [success, failed]` (so it executes regardless of pass/fail).
2. Queries the CircleCI API v2 (`/workflow/{id}/job`) to collect every parallel node's status.
3. Exits non-zero if any node failed, then uses `slack/notify` (`event: fail` / `event: pass`) to send a single aggregated notification.

This addresses a UX problem raised in #502: with `parallelism`, `slack/notify` currently fires once per node, producing duplicate notifications for a single logical test run. There was no documented pattern for collapsing those into one.

## Context

- Issue: #502
- Maintainer go-ahead: https://github.com/CircleCI-Public/slack-orb/issues/502#issuecomment-4480080108 (\"please feel free to open a PR\")
- The pattern itself is in production use in our own CircleCI pipelines, so the YAML reflects a working configuration rather than a theoretical sketch.

## Notes for reviewers

- Uses `$CIRCLE_TOKEN` (CircleCI's standard env var name) rather than `CIRCLECI_TOKEN` used in the original issue body.
- File naming follows the existing `src/examples/` convention (snake_case, verb-led).
- No changes to `README.md` — existing examples are surfaced via the Orb Registry rather than direct README links, so this PR keeps to that convention. Happy to add a README pointer in a follow-up if preferred.

## Test plan

- [x] Confirm YAML lints under the repo's existing config (`.yamllint`).
- [x] Confirm the example renders correctly in the Orb Registry / docs pipeline.